### PR TITLE
Añadir asociación de descripción y precio a piezas y poblado inicial desde general-car-parts.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ replay_pid*
 yarn.lock
 .yarn/
 .pnpm-store/
+package-lock.json

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/model/entitity/core/Product.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/model/entitity/core/Product.java
@@ -16,6 +16,7 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.FetchType;
+import es.ual.dra.autodiagnostico.model.entitity.core.VehicleModel;
 
 /**
  * Entidad que representa un producto asociado a un vehículo.
@@ -24,7 +25,7 @@ import jakarta.persistence.FetchType;
 @Table(name = "product")
 @Getter
 @Setter
-@ToString(exclude = "vehicles")
+@ToString(exclude = "vehicleModels")
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -45,8 +46,8 @@ public class Product {
 
     private String image; // Puede ser nulo
 
-    // Vehículo al que pertenece el producto
+    // VehicleModels a los que está asociado este producto
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "vm_has_product", joinColumns = @JoinColumn(name = "idProduct"), inverseJoinColumns = @JoinColumn(name = "idVehicleModel"))
-    private List<Vehicle> vehicles;
+    private List<VehicleModel> vehicleModels;
 }

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/repository/ProductRepository.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/repository/ProductRepository.java
@@ -3,7 +3,10 @@ package es.ual.dra.autodiagnostico.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import es.ual.dra.autodiagnostico.model.entitity.core.Product;
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    Optional<Product> findByName(String name);
 
 }

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/core/DataPopulationService.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/core/DataPopulationService.java
@@ -38,6 +38,8 @@ public class DataPopulationService {
     private final EngineRepository engineRepository;
     private final ProductRepository productRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    // Cache del JSON de piezas generales
+    private JsonNode generalPartsRoot = null;
 
     // Contiene la marca actual siendo procesada SIN el prefijo "ultimatespecs-" ni
     // otras palabras. Además, está en minúsculas.
@@ -111,6 +113,16 @@ public class DataPopulationService {
     private void processCarPartsForVehicleModel(Path carPartsGroupPath, VehicleModel vehicleModel) {
         try {
             JsonNode carPartRoot = objectMapper.readTree(new File(carPartsGroupPath.toAbsolutePath().toString()));
+            // Cargar el JSON de piezas generales si no está en memoria
+            if (generalPartsRoot == null) {
+                try {
+                    generalPartsRoot = objectMapper
+                            .readTree(getClass().getClassLoader().getResourceAsStream("general-car-parts.json"));
+                } catch (Exception e) {
+                    log.warn("No se pudo leer general-car-parts.json: {}", e.getMessage());
+                    generalPartsRoot = null;
+                }
+            }
             if (carPartRoot.isArray()) {
                 for (JsonNode node : carPartRoot) {
                     String platformGen = node.get("plataforma_generacion").asText();
@@ -118,8 +130,105 @@ public class DataPopulationService {
                     JsonNode parts = node.get("piezas");
                     if (parts.isArray()) {
                         for (JsonNode part : parts) {
-                            // TODO: Guardar pieza
-                            // productRepository.findB
+                            String partName = null;
+                            if (part.isTextual()) {
+                                partName = part.asText();
+                            } else if (part.has("name")) {
+                                partName = part.get("name").asText();
+                            } else if (part.has("pieza")) {
+                                partName = part.get("pieza").asText();
+                            }
+
+                            if (partName == null || partName.isBlank())
+                                continue;
+
+                            // Buscar en el JSON general una pieza que coincida
+                            JsonNode matched = null;
+                            if (generalPartsRoot != null && generalPartsRoot.isArray()) {
+                                String pn = partName.toLowerCase();
+                                for (JsonNode g : generalPartsRoot) {
+                                    if (g.has("name")) {
+                                        String gname = g.get("name").asText().toLowerCase();
+                                        if (gname.equals(pn) || gname.contains(pn)
+                                                || pn.contains(gname.split("\\s")[0])) {
+                                            matched = g;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            String description = null;
+                            Double price = null;
+                            String image = null;
+
+                            if (matched != null) {
+                                if (matched.has("description"))
+                                    description = matched.get("description").asText();
+                                if (matched.has("image"))
+                                    image = matched.get("image").asText();
+                                if (matched.has("priceRange")) {
+                                    String pr = matched.get("priceRange").asText();
+                                    // Extraer números del rango, p. ej. "1500-10000€"
+                                    try {
+                                        String cleaned = pr.replaceAll("[^0-9\\-]", "");
+                                        if (cleaned.contains("-")) {
+                                            String[] partsRange = cleaned.split("-", 2);
+                                            double min = Double.parseDouble(partsRange[0]);
+                                            double max = Double.parseDouble(partsRange[1]);
+                                            price = (min + max) / 2.0; // tomar punto medio
+                                        } else {
+                                            price = Double.parseDouble(cleaned);
+                                        }
+                                    } catch (Exception ex) {
+                                        // ignore parse errors
+                                        log.debug("No se pudo parsear priceRange '{}' para '{}'", pr, partName);
+                                    }
+                                }
+                            }
+
+                            // Guardar o actualizar producto
+                            String canonicalName = partName.trim();
+                            es.ual.dra.autodiagnostico.model.entitity.core.Product product = productRepository
+                                    .findByName(canonicalName).orElse(null);
+                            if (product == null) {
+                                product = es.ual.dra.autodiagnostico.model.entitity.core.Product.builder()
+                                        .name(canonicalName)
+                                        .description(description)
+                                        .price(price)
+                                        .image(image)
+                                        .build();
+                            } else {
+                                // actualizar descripción/price si no existen
+                                if ((product.getDescription() == null || product.getDescription().isBlank())
+                                        && description != null)
+                                    product.setDescription(description);
+                                if (product.getPrice() == null && price != null)
+                                    product.setPrice(price);
+                                if ((product.getImage() == null || product.getImage().isBlank()) && image != null)
+                                    product.setImage(image);
+                            }
+
+                            // Asociar vehicleModel
+                            try {
+                                if (product.getVehicleModels() == null)
+                                    product.setVehicleModels(new ArrayList<>());
+                                // evitar duplicados
+                                boolean exists = false;
+                                for (VehicleModel vm : product.getVehicleModels()) {
+                                    if (vm.getIdVehicleModel() != null
+                                            && vm.getIdVehicleModel().equals(vehicleModel.getIdVehicleModel())) {
+                                        exists = true;
+                                        break;
+                                    }
+                                }
+                                if (!exists)
+                                    product.getVehicleModels().add(vehicleModel);
+                            } catch (Exception ex) {
+                                log.debug("No se pudo asociar product->vehicleModel: {}", ex.getMessage());
+                            }
+
+                            productRepository.save(product);
                         }
                     }
                 }

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/core/GeneralPartsInitializer.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/core/GeneralPartsInitializer.java
@@ -1,0 +1,80 @@
+package es.ual.dra.autodiagnostico.service.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import es.ual.dra.autodiagnostico.model.entitity.core.Product;
+import es.ual.dra.autodiagnostico.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.InputStream;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GeneralPartsInitializer implements ApplicationRunner {
+
+    private final ProductRepository productRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) throws Exception {
+        try {
+            long count = productRepository.count();
+            if (count > 0) {
+                log.info("Products already exist (count={}), skipping general parts initialization", count);
+                return;
+            }
+
+            InputStream is = getClass().getClassLoader().getResourceAsStream("general-car-parts.json");
+            if (is == null) {
+                log.warn("general-car-parts.json not found on classpath");
+                return;
+            }
+
+            JsonNode root = objectMapper.readTree(is);
+            if (root != null && root.isArray()) {
+                for (JsonNode node : root) {
+                    String name = node.has("name") ? node.get("name").asText() : null;
+                    String description = node.has("description") ? node.get("description").asText() : null;
+                    String image = node.has("image") ? node.get("image").asText() : null;
+                    Double price = null;
+                    if (node.has("priceRange")) {
+                        String pr = node.get("priceRange").asText();
+                        try {
+                            String cleaned = pr.replaceAll("[^0-9\\-]", "");
+                            if (cleaned.contains("-")) {
+                                String[] parts = cleaned.split("-", 2);
+                                double min = Double.parseDouble(parts[0]);
+                                double max = Double.parseDouble(parts[1]);
+                                price = (min + max) / 2.0;
+                            } else {
+                                price = Double.parseDouble(cleaned);
+                            }
+                        } catch (Exception e) {
+                            log.debug("Could not parse priceRange {} for {}: {}", pr, name, e.getMessage());
+                        }
+                    }
+
+                    if (name != null) {
+                        Product p = Product.builder()
+                                .name(name.trim())
+                                .description(description)
+                                .price(price)
+                                .image(image)
+                                .build();
+                        productRepository.save(p);
+                    }
+                }
+                log.info("Initialized {} general products", productRepository.count());
+            }
+        } catch (Exception e) {
+            log.error("Error initializing general parts: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Esta PR trata de finalizar lo que @ifm562-ual comenzó, relacionada con la Issue #47.

**Descripción**
Se añade la lógica para asociar a cada pieza (Product) una descripción, imagen y un precio estimado (calculado a partir de `priceRange` en general-car-parts.json) cuando se procesan los JSON de vehículos. Además se incorpora un inicializador automático que inserta las entradas de general-car-parts.json en la tabla `product` si esta está vacía al arrancar la aplicación.

**Qué hace esta PR**
- Mapea piezas detectadas en los JSON de vehículo con las entradas de general-car-parts.json.
- Extrae `description`, `image` y `priceRange` (parsea y calcula el precio medio) y los guarda en `Product`.
- Crea/actualiza `Product` y lo asocia (ManyToMany) con el `VehicleModel` correspondiente.
- Añade `GeneralPartsInitializer` (ApplicationRunner) que puebla `product` desde general-car-parts.json si la tabla está vacía.
- Añade método de búsqueda `findByName` en `ProductRepository`.
- Ajusta la entidad `Product` para relacionarse con `VehicleModel` mediante `vehicleModels`.

**Archivos principales modificados / añadidos**
- DataPopulationService.java
- GeneralPartsInitializer.java (nuevo)
- Product.java
- ProductRepository.java
- Datos utilizados: general-car-parts.json (existente)

**Motivación**
Permitir que el sistema muestre una descripción y una estimación de precio cuando se asocia una pieza a un VehicleModel, mejorando la UX y facilitando futuras integraciones (p. ej. estimaciones económicas, filtros por precio).

**Cómo probar**
1. Asegurar MySQL corriendo y accesible (puerto 3306).
2. Construir y arrancar backend:
```bash
cd backend
mvn -DskipTests package
mvn spring-boot:run -Dspring-boot.run.profiles=local
```
3. En los logs deberías ver un mensaje del inicializador indicando cuántos `Product` insertó si la tabla estaba vacía.
4. Ejecutar el proceso que lee los JSON de `scraper-output` (el flujo habitual de población). Al finalizar, comprobar en la BD:
```sql
SELECT idProduct, name, description, price, image FROM product LIMIT 50;
SELECT * FROM vm_has_product LIMIT 50;
```
5. En la UI (o curl) comprobar que, al consultar datos del VehicleModel, existen `Product` asociados con descripción y precio.

**Detalles técnicos y heurística**
- Matching: se aplica una heurística práctica (comparaciones `equals`/`contains` y token inicial) para emparejar nombres entre los JSON de vehículo y general-car-parts.json. No es infalible.
- Precio: se limpia la cadena `priceRange` y si es un rango `min-max` se toma la media como `price`. Si solo hay un número, se usa tal cual.
- Actualizaciones: si existe ya un `Product` con el mismo `name`, se actualizan `description`, `image` o `price` solo si estaban vacíos.
- Inicializador: solo inserta si `product.count() == 0` para evitar duplicados/recargas indeseadas.

**Limitaciones conocidas**
- El emparejado de nombres puede producir falsos positivos o no detectar sinónimos. Recomendable mejorar con fuzzy matching (Levenshtein) o un diccionario de sinónimos.
- El proceso guarda cada `Product` de forma individual; para lotes grandes podría optimizarse con batch inserts.
- Cambié el mapeo ManyToMany en `Product` a `vehicleModels`. Revisar si hay código adicional que dependa del mapeo anterior.

**Recomendaciones / próximos pasos**
- (Opcional) Mejorar la heurística de matching (fuzzy matching) y añadir tests unitarios para `DataPopulationService`.
- Añadir pruebas de integración para `GeneralPartsInitializer`.
- Revisar el modelo de datos y añadir la relación inversa en `VehicleModel` si se desea navegación bidireccional.
- Documentar el formato esperado de los JSON de piezas (clave `piezas`, formato de `priceRange`).

**Checklist antes de merge**
- [ ] Revisar impacto del nuevo mapeo ManyToMany en el resto del código.
- [ ] Ejecutar la población local y validar registros en la tabla `product`.
- [ ] Añadir tests (recomendado).