### PR TITLE
frontend: habilitar fetch en HttpClient para SSR

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,6 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 import { routes } from './app.routes';
 /* import { provideClientHydration, withEventReplay } from '@angular/platform-browser';*/
@@ -9,6 +9,6 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
-    provideHttpClient(),
+    provideHttpClient(withFetch()),
   ]
 };

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,4 +1,7 @@
 import { NgModule } from '@angular/core';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
-@NgModule({})
+@NgModule({
+	providers: [provideHttpClient(withFetch())]
+})
 export class AppModule {}


### PR DESCRIPTION
- Se añadió provideHttpClient(withFetch()) en frontend/src/app/app.module.ts\n- Se actualizó frontend/src/app/app.config.ts para usar provideHttpClient(withFetch()) en el ApplicationConfig\n- Motivo: resolver la advertencia NG02801 y mejorar compatibilidad y rendimiento en Server-Side Rendering (Angular Universal)