### PR TITLE
Cambios en application.properties.

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # JPA / Hibernate Configuration
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,6 +1,3 @@
-spring.application.name=Autodiagnostico-Test
-server.port=8081
-
 # Data Source Configuration (MySQL - Test)
 # spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/autodiagnostico?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true}
 # spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
@@ -25,7 +22,7 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-JPA / Hibernate Configuration
+# JPA / Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
Se cambia spring.jpa.hibernate.ddl-auto a create-drop para regenerar el esquema al reiniciar la base de datos y mantener sincronizado el diseño con las entidades durante el desarrollo. En producción se seguirá usando update.