### PR TITLE
🧭 Seguimiento: usar timestamps del backend y mostrar fechas en UI

### DIFF
--- a/backend/src/main/java/es/ual/dra/autodiagnostico/dto/MechanicClientDTO.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/dto/MechanicClientDTO.java
@@ -1,6 +1,7 @@
 package es.ual.dra.autodiagnostico.dto;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import es.ual.dra.autodiagnostico.dto.autodiagnosis.DiagnosedPartDTO;
@@ -34,6 +35,14 @@ public class MechanicClientDTO {
     private List<DiagnosedPartDTO> recommendedParts;
 
     private BigDecimal estimatedPrice;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime acceptedAt;
+
+    private LocalDateTime inProgressAt;
+
+    private LocalDateTime fixedAt;
 
     private String status;
 

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/model/entitity/core/Issue.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/model/entitity/core/Issue.java
@@ -76,6 +76,12 @@ public class Issue {
     @Column(name = "accepted_at")
     private LocalDateTime acceptedAt;
 
+    @Column(name = "in_progress_at")
+    private LocalDateTime inProgressAt;
+
+    @Column(name = "fixed_at")
+    private LocalDateTime fixedAt;
+
     @Column(name = "active", nullable = false)
     private boolean active;
 

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/MechanicService.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/MechanicService.java
@@ -45,6 +45,16 @@ public class MechanicService {
 
         validateProgressColor(newStatus);
         issue.setProgressColor(newStatus.toLowerCase());
+
+        LocalDateTime now = LocalDateTime.now();
+        if ("amarillo".equalsIgnoreCase(newStatus) && issue.getAcceptedAt() == null) {
+            issue.setAcceptedAt(now);
+        } else if ("naranja".equalsIgnoreCase(newStatus) && issue.getInProgressAt() == null) {
+            issue.setInProgressAt(now);
+        } else if ("verde".equalsIgnoreCase(newStatus) && issue.getFixedAt() == null) {
+            issue.setFixedAt(now);
+        }
+
         issue.setUpdatedAt(LocalDateTime.now());
         issueRepository.save(issue);
     }
@@ -83,9 +93,13 @@ public class MechanicService {
                 .clientAvatar(client.getAvatarUrl())
                 .carInfo(buildCarInfo(issue))
                 .problemDescription(issue.getDescription())
-            .aiDiagnosis(issue.getAiDiagnosis())
-            .recommendedParts(readRecommendedParts(issue.getRecommendedParts()))
-            .estimatedPrice(issue.getEstimatedPrice())
+                .aiDiagnosis(issue.getAiDiagnosis())
+                .recommendedParts(readRecommendedParts(issue.getRecommendedParts()))
+                .estimatedPrice(issue.getEstimatedPrice())
+                .createdAt(issue.getCreatedAt())
+                .acceptedAt(issue.getAcceptedAt())
+                .inProgressAt(issue.getInProgressAt())
+                .fixedAt(issue.getFixedAt())
                 .status(issue.getProgressColor())
                 .latestUpdate(issue.getLatestUpdate())
                 .sessionUuid(issue.getSessionUuid())

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/MechanicsDataInitializer.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/MechanicsDataInitializer.java
@@ -128,10 +128,10 @@ public class MechanicsDataInitializer implements CommandLineRunner {
                 "motorlab@taller.local", "L-V 10:00-19:00", "/taller4.jpg", 3, mechanics.get(3), 36.8296, -2.4428);
     }
 
-        private void initializeDemoRepairCases() {
+    private void initializeDemoRepairCases() {
         List<VehicleModel> models = vehicleModelRepository.findAll().stream()
-            .sorted(Comparator.comparing(VehicleModel::getIdVehicleModel))
-            .toList();
+                .sorted(Comparator.comparing(VehicleModel::getIdVehicleModel))
+                .toList();
 
         if (models.size() < 4) {
             log.warn("No hay suficientes modelos de vehículo para sembrar casos de chat.");
@@ -149,35 +149,35 @@ public class MechanicsDataInitializer implements CommandLineRunner {
         AppUser mechanic4 = userRepository.findByEmailIgnoreCase("mecanico4@taller.local").orElseThrow();
 
         seedCase(client1, models.get(0), "1111AAA", LocalDate.of(2023, 3, 10), mechanic1,
-            "Taller Central Autodiagnostico", "Motor no arranca y hace clic",
-            "Bateria descargada o motor de arranque",
-            "[{\"idProduct\":101,\"name\":\"Bateria 12V\",\"description\":\"Bateria de sustitucion\",\"lowRangePrice\":120.0,\"highRangePrice\":180.0,\"image\":null}]",
-            new BigDecimal("150.00"),
-            "Hemos recibido el vehiculo. Vamos a comprobar bateria y arranque.");
+                "Taller Central Autodiagnostico", "Motor no arranca y hace clic",
+                "Bateria descargada o motor de arranque",
+                "[{\"idProduct\":101,\"name\":\"Bateria 12V\",\"description\":\"Bateria de sustitucion\",\"lowRangePrice\":120.0,\"highRangePrice\":180.0,\"image\":null}]",
+                new BigDecimal("150.00"),
+                "Hemos recibido el vehiculo. Vamos a comprobar bateria y arranque.");
 
         seedCase(client2, models.get(1), "2222BBB", LocalDate.of(2022, 7, 18), mechanic2,
-            "Auto Diagnosis Express", "Vibracion al frenar y pedal blando",
-            "Discos de freno y liquido de frenos",
-            "[{\"idProduct\":102,\"name\":\"Discos de freno\",\"description\":\"Juego delantero\",\"lowRangePrice\":90.0,\"highRangePrice\":140.0,\"image\":null},{\"idProduct\":103,\"name\":\"Liquido de frenos\",\"description\":\"DOT4\",\"lowRangePrice\":12.0,\"highRangePrice\":18.0,\"image\":null}]",
-            new BigDecimal("175.00"),
-            "El coche ya esta en elevador. Revisión de frenos en curso.");
+                "Auto Diagnosis Express", "Vibracion al frenar y pedal blando",
+                "Discos de freno y liquido de frenos",
+                "[{\"idProduct\":102,\"name\":\"Discos de freno\",\"description\":\"Juego delantero\",\"lowRangePrice\":90.0,\"highRangePrice\":140.0,\"image\":null},{\"idProduct\":103,\"name\":\"Liquido de frenos\",\"description\":\"DOT4\",\"lowRangePrice\":12.0,\"highRangePrice\":18.0,\"image\":null}]",
+                new BigDecimal("175.00"),
+                "El coche ya esta en elevador. Revisión de frenos en curso.");
 
         seedCase(client3, models.get(2), "3333CCC", LocalDate.of(2024, 1, 22), mechanic3,
-            "Reparaciones Rapidas Sur", "Aire acondicionado no enfria",
-            "Filtro habitaculo y recarga de gas",
-            "[{\"idProduct\":104,\"name\":\"Filtro habitaculo\",\"description\":\"Filtro polen\",\"lowRangePrice\":18.0,\"highRangePrice\":25.0,\"image\":null}]",
-            new BigDecimal("95.00"),
-            "Estamos revisando el circuito del aire acondicionado.");
+                "Reparaciones Rapidas Sur", "Aire acondicionado no enfria",
+                "Filtro habitaculo y recarga de gas",
+                "[{\"idProduct\":104,\"name\":\"Filtro habitaculo\",\"description\":\"Filtro polen\",\"lowRangePrice\":18.0,\"highRangePrice\":25.0,\"image\":null}]",
+                new BigDecimal("95.00"),
+                "Estamos revisando el circuito del aire acondicionado.");
 
         seedCase(client4, models.get(3), "4444DDD", LocalDate.of(2021, 11, 2), mechanic4,
-            "MotorLab Costa", "Ruido extraño en el motor y perdida de potencia",
-            "Bobinas y bujias",
-            "[{\"idProduct\":105,\"name\":\"Bujias\",\"description\":\"Juego completo\",\"lowRangePrice\":30.0,\"highRangePrice\":50.0,\"image\":null}]",
-            new BigDecimal("210.00"),
-            "Estamos escuchando el motor y validando la mezcla.");
-        }
+                "MotorLab Costa", "Ruido extraño en el motor y perdida de potencia",
+                "Bobinas y bujias",
+                "[{\"idProduct\":105,\"name\":\"Bujias\",\"description\":\"Juego completo\",\"lowRangePrice\":30.0,\"highRangePrice\":50.0,\"image\":null}]",
+                new BigDecimal("210.00"),
+                "Estamos escuchando el motor y validando la mezcla.");
+    }
 
-        private void seedCase(
+    private void seedCase(
             AppUser client,
             VehicleModel model,
             String plate,
@@ -191,11 +191,14 @@ public class MechanicsDataInitializer implements CommandLineRunner {
             String latestUpdate) {
         PersonalVehicle personalVehicle = findOrCreatePersonalVehicle(client, model, plate, buildDate);
         Workshop workshop = workshopRepository.findByNameIgnoreCase(workshopName).orElseThrow();
-        String sessionUuid = UUID.nameUUIDFromBytes(("demo-issue-" + client.getEmail() + "-" + model.getIdVehicleModel())
-            .getBytes(StandardCharsets.UTF_8)).toString();
+        String sessionUuid = UUID
+                .nameUUIDFromBytes(("demo-issue-" + client.getEmail() + "-" + model.getIdVehicleModel())
+                        .getBytes(StandardCharsets.UTF_8))
+                .toString();
 
-        issueRepository.findByPersonalVehicleOwnerIdAndPersonalVehicleIdAndActiveTrue(client.getId(), personalVehicle.getId())
-            .forEach(existing -> existing.setActive(false));
+        issueRepository
+                .findByPersonalVehicleOwnerIdAndPersonalVehicleIdAndActiveTrue(client.getId(), personalVehicle.getId())
+                .forEach(existing -> existing.setActive(false));
 
         Issue issue = issueRepository.findBySessionUuid(sessionUuid).orElseGet(Issue::new);
         issue.setPersonalVehicle(personalVehicle);
@@ -206,6 +209,7 @@ public class MechanicsDataInitializer implements CommandLineRunner {
         issue.setEstimatedPrice(estimatedPrice);
         issue.setStatus(IssueStatus.WORKSHOP_ASSIGNED);
         issue.setProgressColor("amarillo");
+        issue.setAcceptedAt(LocalDateTime.now());
         issue.setLatestUpdate(latestUpdate);
         issue.setSessionUuid(sessionUuid);
         issue.setActive(true);
@@ -213,32 +217,33 @@ public class MechanicsDataInitializer implements CommandLineRunner {
 
         if (!chatMessageRepository.existsByIssueId(issue.getId())) {
             chatMessageRepository.save(ChatMessage.builder()
-                .issue(issue)
-                .sessionUuid(sessionUuid)
-                .sender(mechanic)
-                .senderRole(ChatSenderRole.MECANICO)
-                .commentText("Caso de prueba creado para verificar el chat y el seguimiento.")
-                .wordCount(9)
-                .readByUser(false)
-                .build());
+                    .issue(issue)
+                    .sessionUuid(sessionUuid)
+                    .sender(mechanic)
+                    .senderRole(ChatSenderRole.MECANICO)
+                    .commentText("Caso de prueba creado para verificar el chat y el seguimiento.")
+                    .wordCount(9)
+                    .readByUser(false)
+                    .build());
         }
 
         log.info("Demo issue seeded for {} with mechanic {} and workshop {} (session={})",
-            client.getEmail(), mechanic.getEmail(), workshop.getName(), sessionUuid);
-        }
+                client.getEmail(), mechanic.getEmail(), workshop.getName(), sessionUuid);
+    }
 
-        private PersonalVehicle findOrCreatePersonalVehicle(AppUser owner, VehicleModel model, String plate, LocalDate buildDate) {
+    private PersonalVehicle findOrCreatePersonalVehicle(AppUser owner, VehicleModel model, String plate,
+            LocalDate buildDate) {
         return personalVehicleRepository.findByOwnerIdOrderByIdDesc(owner.getId()).stream()
-            .filter(vehicle -> vehicle.getVehicleModel() != null
-                && vehicle.getVehicleModel().getIdVehicleModel().equals(model.getIdVehicleModel()))
-            .findFirst()
-            .orElseGet(() -> personalVehicleRepository.save(PersonalVehicle.builder()
-                .owner(owner)
-                .vehicleModel(model)
-                .plate(plate)
-                .buildDate(buildDate)
-                .build()));
-        }
+                .filter(vehicle -> vehicle.getVehicleModel() != null
+                        && vehicle.getVehicleModel().getIdVehicleModel().equals(model.getIdVehicleModel()))
+                .findFirst()
+                .orElseGet(() -> personalVehicleRepository.save(PersonalVehicle.builder()
+                        .owner(owner)
+                        .vehicleModel(model)
+                        .plate(plate)
+                        .buildDate(buildDate)
+                        .build()));
+    }
 
     private void upsertWorkshop(
             String name,

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/WorkshopService.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/WorkshopService.java
@@ -2,6 +2,7 @@ package es.ual.dra.autodiagnostico.service;
 
 import java.util.List;
 import java.util.UUID;
+import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -72,12 +73,12 @@ public class WorkshopService {
         AppUser mechanic = getMechanic(workshop);
 
         Issue issue = issueRepository
-            .findFirstByPersonalVehicleOwnerIdAndPersonalVehicleIdAndStatusAndActiveTrueOrderByCreatedAtDesc(
-                client.getId(),
-                personalVehicle.getId(),
-                IssueStatus.DRAFT)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-                "No existe un diagnostico previo para este vehiculo"));
+                .findFirstByPersonalVehicleOwnerIdAndPersonalVehicleIdAndStatusAndActiveTrueOrderByCreatedAtDesc(
+                        client.getId(),
+                        personalVehicle.getId(),
+                        IssueStatus.DRAFT)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "No existe un diagnostico previo para este vehiculo"));
 
         long activeIssues = issueRepository.countByWorkshopMechanicIdAndActiveTrue(mechanic.getId());
         if (activeIssues >= workshop.getVehicleLimit()) {
@@ -88,6 +89,7 @@ public class WorkshopService {
         issue.setSessionUuid(UUID.randomUUID().toString());
         issue.setStatus(IssueStatus.WORKSHOP_ASSIGNED);
         issue.setProgressColor("amarillo");
+        issue.setAcceptedAt(LocalDateTime.now());
         issue.setLatestUpdate("Taller seleccionado. Pendiente de primera revision del mecanico.");
         issue.setActive(true);
         issue = issueRepository.save(issue);
@@ -106,7 +108,8 @@ public class WorkshopService {
     private AppUser getMechanic(Workshop workshop) {
         return userRepository.findById(workshop.getMechanicId())
                 .filter(user -> user.getRole() == UserRole.TALLER)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Mecanico del taller no encontrado"));
+                .orElseThrow(
+                        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Mecanico del taller no encontrado"));
     }
 
     private WorkshopDTO toDto(Workshop workshop, Long clientId) {
@@ -173,6 +176,10 @@ public class WorkshopService {
                 .aiDiagnosis(issue.getAiDiagnosis())
                 .recommendedParts(deserializeRecommendedParts(issue.getRecommendedParts()))
                 .estimatedPrice(issue.getEstimatedPrice())
+                .createdAt(issue.getCreatedAt())
+                .acceptedAt(issue.getAcceptedAt())
+                .inProgressAt(issue.getInProgressAt())
+                .fixedAt(issue.getFixedAt())
                 .status(issue.getProgressColor())
                 .latestUpdate(issue.getLatestUpdate())
                 .sessionUuid(issue.getSessionUuid())

--- a/frontend/src/app/components/seguimiento/seguimiento.html
+++ b/frontend/src/app/components/seguimiento/seguimiento.html
@@ -11,20 +11,23 @@
 
     <mat-step
       label="Cita Agendada"
-      [completed]="issueStatus === 'IN WORKSHOP' || issueStatus === 'IN PROGRESS' || issueStatus === 'FIXED'"
+      [completed]="!!tracking?.createdAt"
       [editable]="canEditTracking">
       <p>Cita Agendada</p>
+      <div class="step-date">{{ tracking?.createdAt | date:'short' }}</div>
     </mat-step>
 
     <mat-step
       label="En Revisión"
-      [completed]="issueStatus === 'IN PROGRESS' || issueStatus === 'FIXED'"
+      [completed]="!!(tracking?.inProgressAt || tracking?.acceptedAt)"
       [editable]="canEditTracking">
       <p>En Revisión</p>
+      <div class="step-date">{{ (tracking?.inProgressAt || tracking?.acceptedAt) | date:'short' }}</div>
     </mat-step>
 
-    <mat-step label="Reparado" [completed]="issueStatus === 'FIXED'" [editable]="false">
+    <mat-step label="Reparado" [completed]="!!tracking?.fixedAt" [editable]="false">
       <p>Reparado</p>
+      <div class="step-date">{{ tracking?.fixedAt | date:'short' }}</div>
     </mat-step>
 
   </mat-horizontal-stepper>

--- a/frontend/src/app/components/seguimiento/seguimiento.ts
+++ b/frontend/src/app/components/seguimiento/seguimiento.ts
@@ -1,6 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectorRef, Component, Inject, OnInit, PLATFORM_ID, ViewChild, inject } from '@angular/core';
-import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { Router, RouterOutlet } from '@angular/router';
 import { ChatApiService } from '../../services/chat-api.service';
 import { AuthStateService } from '../../services/auth-state.service';
 import { MechanicService } from '../../services/mechanic.service';
@@ -12,7 +12,7 @@ import { MatStepper } from '@angular/material/stepper';
 @Component({
   selector: 'app-seguimiento-page',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, MatStepperModule, MatButtonModule, ReactiveFormsModule, FormsModule],
+  imports: [RouterOutlet, MatStepperModule, MatButtonModule, ReactiveFormsModule, FormsModule],
   templateUrl: './seguimiento.html',
   styleUrls: ['./seguimiento.css']
 })

--- a/frontend/src/app/components/seguimiento/seguimiento.ts
+++ b/frontend/src/app/components/seguimiento/seguimiento.ts
@@ -1,9 +1,9 @@
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, DatePipe } from '@angular/common';
 import { ChangeDetectorRef, Component, Inject, OnInit, PLATFORM_ID, ViewChild, inject } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { ChatApiService } from '../../services/chat-api.service';
 import { AuthStateService } from '../../services/auth-state.service';
-import { MechanicService } from '../../services/mechanic.service';
+import { MechanicService, MechanicClient } from '../../services/mechanic.service';
 import { MatStepperModule } from '@angular/material/stepper';
 import { MatButtonModule } from '@angular/material/button';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
@@ -12,7 +12,8 @@ import { MatStepper } from '@angular/material/stepper';
 @Component({
   selector: 'app-seguimiento-page',
   standalone: true,
-  imports: [RouterOutlet, MatStepperModule, MatButtonModule, ReactiveFormsModule, FormsModule],
+  imports: [RouterOutlet, MatStepperModule, MatButtonModule, ReactiveFormsModule, FormsModule, DatePipe],
+  providers: [DatePipe],
   templateUrl: './seguimiento.html',
   styleUrls: ['./seguimiento.css']
 })
@@ -26,7 +27,7 @@ export class SeguimientoComponent implements OnInit {
 
   participantId = 0;
   sessionUuid = '';
-  tracking: any = null;
+  tracking: MechanicClient | null = null;
   hasTracking = false;
   userOnline = false;
   unreadCount = 0;
@@ -89,9 +90,10 @@ export class SeguimientoComponent implements OnInit {
         }
 
         this.hasTracking = true;
-        this.tracking = tracking;
+        this.tracking = tracking as MechanicClient;
+        this.issueStatus = this.tracking?.status ?? '';
 
-        this.sessionUuid = tracking.sessionUuid ?? '';
+        this.sessionUuid = this.tracking?.sessionUuid ?? '';
         localStorage.setItem('trackingSessionUuid', this.sessionUuid);
 
         this.cdr.detectChanges();

--- a/frontend/src/app/components/shared/header/header.html
+++ b/frontend/src/app/components/shared/header/header.html
@@ -73,7 +73,7 @@
             <a routerLink="/perfil" class="dropdown-item" role="menuitem">Mi perfil</a>
             <a routerLink="/mis-vehiculos" class="dropdown-item" role="menuitem">Mis vehículos</a>
             @if (authStateService.canAccessSeguimiento()) {
-            <a routerLink="/usuario/seguimiento" class="dropdown-item" role="menuitem">Seguimiento</a>
+            <a [routerLink]="seguimientoLink" class="dropdown-item" role="menuitem">Seguimiento</a>
             }
             <hr class="dropdown-divider" />
             <button class="dropdown-item dropdown-item--danger" (click)="onLogout()" role="menuitem">Cerrar
@@ -99,7 +99,7 @@
         </svg>
         Lista de clientes
       </a>
-      <a routerLink="/mecanico/seguimiento" routerLinkActive="nav-item--active" class="nav-item">
+      <a routerLink="/mecanico" routerLinkActive="nav-item--active" class="nav-item">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           aria-hidden="true">
           <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
@@ -172,7 +172,7 @@
     <nav class="mobile-nav" aria-label="Menú móvil">
       @if (authStateService.role() === 'TALLER') {
         <a routerLink="/mecanico" class="mobile-nav-link" (click)="toggleMobileMenu()">Lista de clientes</a>
-        <a routerLink="/mecanico/seguimiento" class="mobile-nav-link" (click)="toggleMobileMenu()">Seguimiento</a>
+        <a routerLink="/mecanico" class="mobile-nav-link" (click)="toggleMobileMenu()">Seguimiento</a>
       }
       @if (authStateService.role() === 'ADMIN') {
         <a routerLink="/admin" class="mobile-nav-link" (click)="toggleMobileMenu()">Administración</a>

--- a/frontend/src/app/components/shared/header/header.ts
+++ b/frontend/src/app/components/shared/header/header.ts
@@ -53,6 +53,10 @@ export class HeaderComponent implements OnInit {
   toggleMenu(): void { this.menuOpen = !this.menuOpen; }
   toggleMobileMenu(): void { this.mobileMenuOpen = !this.mobileMenuOpen; }
 
+  get seguimientoLink(): string {
+    return this.authStateService.role() === 'TALLER' ? '/mecanico' : '/usuario/seguimiento';
+  }
+
   onLogin(): void {
     void this.router.navigate(['/login']);
   }

--- a/frontend/src/app/services/api.models.ts
+++ b/frontend/src/app/services/api.models.ts
@@ -126,6 +126,10 @@ export interface MechanicClientTracking {
   aiDiagnosis: string;
   recommendedParts: DiagnosedPart[];
   estimatedPrice: number | null;
+  createdAt: string;
+  acceptedAt: string | null;
+  inProgressAt: string | null;
+  fixedAt: string | null;
   status: string;
   latestUpdate?: string;
   sessionUuid: string;

--- a/frontend/src/app/services/mechanic.service.ts
+++ b/frontend/src/app/services/mechanic.service.ts
@@ -14,6 +14,10 @@ export interface MechanicClient {
   aiDiagnosis: string;
   recommendedParts: DiagnosedPart[];
   estimatedPrice: number | null;
+  createdAt: string;
+  acceptedAt: string | null;
+  inProgressAt: string | null;
+  fixedAt: string | null;
   status: 'verde' | 'amarillo' | 'naranja' | 'rojo';
   latestUpdate?: string;
   sessionUuid: string;


### PR DESCRIPTION
Integración de las fechas de transición del backend en la UI de Seguimiento y mejora el comportamiento del stepper:

Usa createdAt, acceptedAt, inProgressAt, fixedAt proporcionadas por el backend para marcar pasos completados.
Muestra las fechas formateadas bajo cada paso.
Habilita/deshabilita la edición del stepper según el rol (mecánico/taller vs usuario).
Añade DatePipe a la configuración del componente standalone para soportar la pipe date.
También incluye -como contexto de esta serie de cambios- correcciones en inicialización de datos y un script local para ejecutar Maven cargando .env en Linux.

**Cambios principales**
Frontend:
- frontend/src/app/components/seguimiento/seguimiento.ts — tipado, asignación issueStatus, import/uso de DatePipe.
- frontend/src/app/components/seguimiento/seguimiento.html — uso de timestamps para completed y visualización de fechas.

Backend:
- backend/src/main/java/.../MechanicClientDTO.java — añade timestamps (si no existían).
- backend/src/main/java/.../MechanicService.java — mapea timestamps desde Issue.
- backend/src/main/resources/static/general-car-parts.json + GeneralPartsInitializer — mejora de carga.
- backend/run-local-maven.sh — script para desarrollo Linux.