### PR TITLE
feat: botón guardar coche, refactor selector mis vehículos, fixes diagnóstico y perf de queries de vehículos

### DIFF
--- a/backend/src/main/java/es/ual/dra/autodiagnostico/dto/PersonalVehicleResponseDTO.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/dto/PersonalVehicleResponseDTO.java
@@ -18,6 +18,7 @@ public class PersonalVehicleResponseDTO {
     private Long id;
     private Long ownerId;
     private Long vehicleModelId;
+    private Long vehicleId;
 
     private String brand;
     private String vehicleName;

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/repository/VehicleModelRepository.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/repository/VehicleModelRepository.java
@@ -5,10 +5,13 @@ import es.ual.dra.autodiagnostico.model.entitity.core.VehicleModel;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface VehicleModelRepository extends JpaRepository<VehicleModel, Long> {
 
     Optional<VehicleModel> findByModelNameAndVehicle(String modelName, Vehicle vehicle);
+
+    List<VehicleModel> findByVehicle_IdVehicleOrderByModelNameAsc(Long idVehicle);
 }

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/repository/VehicleRepository.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/repository/VehicleRepository.java
@@ -1,6 +1,10 @@
 package es.ual.dra.autodiagnostico.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import es.ual.dra.autodiagnostico.model.entitity.core.Vehicle;
@@ -10,5 +14,10 @@ import es.ual.dra.autodiagnostico.model.entitity.core.Vehicle;
  */
 @Repository
 public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
-    java.util.Optional<Vehicle> findByNameAndBrand(String name, String brand);
+    Optional<Vehicle> findByNameAndBrand(String name, String brand);
+
+    @Query("SELECT DISTINCT v.brand FROM Vehicle v WHERE v.brand IS NOT NULL AND v.brand <> '' ORDER BY v.brand")
+    List<String> findDistinctBrandsOrdered();
+
+    List<Vehicle> findByBrandIgnoreCaseOrderByNameAsc(String brand);
 }

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/IssueService.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/IssueService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,6 +58,7 @@ public class IssueService {
                 .status(IssueStatus.DRAFT)
                 .progressColor("gris")
                 .latestUpdate("Diagnóstico IA creado. Pendiente de asignar taller.")
+                .sessionUuid(UUID.randomUUID().toString())
                 .active(true)
                 .build();
 

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/PersonalVehicleService.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/PersonalVehicleService.java
@@ -87,6 +87,7 @@ public class PersonalVehicleService {
                 .id(pv.getId())
                 .ownerId(pv.getOwner() == null ? null : pv.getOwner().getId())
                 .vehicleModelId(model == null ? null : model.getIdVehicleModel())
+                .vehicleId(vehicle == null ? null : vehicle.getIdVehicle())
                 .brand(vehicle == null ? null : vehicle.getBrand())
                 .vehicleName(vehicle == null ? null : vehicle.getName())
                 .modelName(model == null ? null : model.getModelName())

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/WorkshopService.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/WorkshopService.java
@@ -1,7 +1,6 @@
 package es.ual.dra.autodiagnostico.service;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -88,7 +87,6 @@ public class WorkshopService {
         }
 
         issue.setWorkshop(workshop);
-        issue.setSessionUuid(UUID.randomUUID().toString());
         issue.setStatus(IssueStatus.WORKSHOP_ASSIGNED);
         issue.setProgressColor("amarillo");
         issue.setLatestUpdate("Taller seleccionado. Pendiente de primera revision del mecanico.");

--- a/backend/src/main/java/es/ual/dra/autodiagnostico/service/vehicle/VehicleServiceImpl.java
+++ b/backend/src/main/java/es/ual/dra/autodiagnostico/service/vehicle/VehicleServiceImpl.java
@@ -3,7 +3,6 @@ package es.ual.dra.autodiagnostico.service.vehicle;
 import es.ual.dra.autodiagnostico.dto.VehicleModelSummaryDTO;
 import es.ual.dra.autodiagnostico.dto.VehicleVariantDTO;
 import es.ual.dra.autodiagnostico.model.entitity.core.EngineType;
-import es.ual.dra.autodiagnostico.model.entitity.core.Vehicle;
 import es.ual.dra.autodiagnostico.model.entitity.core.VehicleModel;
 import es.ual.dra.autodiagnostico.repository.VehicleModelRepository;
 import es.ual.dra.autodiagnostico.repository.VehicleRepository;
@@ -21,37 +20,21 @@ public class VehicleServiceImpl implements VehicleService {
 
     @Override
     public List<String> getBrands() {
-        return vehicleRepository.findAll().stream()
-                .map(Vehicle::getBrand)
-                .filter(b -> b != null && !b.isBlank())
-                .distinct()
-                .sorted()
-                .toList();
+        return vehicleRepository.findDistinctBrandsOrdered();
     }
 
     @Override
     public List<VehicleModelSummaryDTO> getModelsByBrand(String brand) {
-        return vehicleRepository.findAll().stream()
-                .filter(v -> brand.equalsIgnoreCase(v.getBrand()))
+        return vehicleRepository.findByBrandIgnoreCaseOrderByNameAsc(brand).stream()
                 .map(v -> new VehicleModelSummaryDTO(v.getIdVehicle(), v.getName()))
-                .sorted((a, b) -> a.name().compareToIgnoreCase(b.name()))
                 .toList();
     }
 
     @Override
     public List<VehicleVariantDTO> getVariantsByVehicleId(Long vehicleId) {
-        return vehicleRepository.findById(vehicleId)
-                .map(vehicle -> vehicleModelRepository.findAll().stream()
-                        .filter(vm -> vm.getVehicle() != null
-                                && vm.getVehicle().getIdVehicle().equals(vehicleId))
-                        .map(this::toVariantDTO)
-                        .sorted((a, b) -> {
-                            String na = a.modelName() != null ? a.modelName() : "";
-                            String nb = b.modelName() != null ? b.modelName() : "";
-                            return na.compareToIgnoreCase(nb);
-                        })
-                        .toList())
-                .orElse(List.of());
+        return vehicleModelRepository.findByVehicle_IdVehicleOrderByModelNameAsc(vehicleId).stream()
+                .map(this::toVariantDTO)
+                .toList();
     }
 
     private VehicleVariantDTO toVariantDTO(VehicleModel vm) {

--- a/frontend/src/app/components/diagnostico/diagnostico.css
+++ b/frontend/src/app/components/diagnostico/diagnostico.css
@@ -1,0 +1,111 @@
+:host { display: block; }
+
+.diagnostico-page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.estado { padding: 2rem; text-align: center; }
+.estado--error { color: #b00020; }
+.estado--success {
+  color: #1f5e24;
+  background: #e8f5e9;
+  border: 1px solid #a5d6a7;
+  border-radius: 0.4rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+}
+
+.cabecera h1 { margin: 0 0 0.5rem; }
+.diagnosis { font-size: 1.15rem; font-weight: 600; margin: 0 0 1rem; }
+
+.confidence {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+.confidence__bar {
+  flex: 1;
+  height: 0.6rem;
+  background: #eee;
+  border-radius: 0.3rem;
+  overflow: hidden;
+}
+.confidence__fill {
+  height: 100%;
+  background: #2e7d32;
+  transition: width 0.4s;
+}
+
+.explanation { color: #444; line-height: 1.5; }
+
+.piezas {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+.pieza {
+  border: 1px solid #ddd;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: #fff;
+}
+.pieza img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 0.35rem;
+  background: #f5f5f5;
+}
+.pieza__info h3 { margin: 0 0 0.25rem; font-size: 1rem; }
+.pieza__info p { margin: 0; font-size: 0.9rem; color: #555; }
+.pieza__precio { font-weight: 600; color: #1565c0; }
+
+.sin-piezas { color: #555; font-style: italic; }
+
+.aviso {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background: #fff8e1;
+  border-left: 4px solid #f9a825;
+  border-radius: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.boton-volver {
+  margin-top: 2rem;
+  padding: 0.6rem 1.2rem;
+  background: #1565c0;
+  color: white;
+  border: none;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.boton-volver:hover { background: #0d47a1; }
+
+.boton-aceptar {
+  margin-top: 0.75rem;
+  margin-left: 0.75rem;
+  padding: 0.6rem 1.2rem;
+  background: #2e7d32;
+  color: white;
+  border: none;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.boton-aceptar:hover { background: #1f5e24; }
+.boton-aceptar:disabled { opacity: 0.7; cursor: not-allowed; }
+
+:host(.dark) .diagnostico-page {
+  color: #ffffff;
+  background: #1f2937;
+}

--- a/frontend/src/app/components/diagnostico/diagnostico.html
+++ b/frontend/src/app/components/diagnostico/diagnostico.html
@@ -1,0 +1,86 @@
+<section class="diagnostico-page">
+  @if (successMessage()) {
+    <div class="estado estado--success" role="status" aria-live="polite">
+      <p>{{ successMessage() }}</p>
+    </div>
+  }
+
+  @if (loading()) {
+    <div class="estado estado--loading">
+      <p>Analizando síntomas con el asistente IA…</p>
+    </div>
+  } @else if (errorMessage()) {
+    <div class="estado estado--error">
+      <h2>No se pudo completar el diagnóstico</h2>
+      <p>{{ errorMessage() }}</p>
+      <button type="button" (click)="volverAHome()">Volver</button>
+    </div>
+  } @else if (resultado(); as r) {
+    <header class="cabecera">
+      <h1>Diagnóstico estimado</h1>
+      <p class="diagnosis">{{ r.diagnosis }}</p>
+
+      <div class="confidence" [attr.aria-label]="'Confianza ' + (r.confidence * 100 | number:'1.0-0') + '%'">
+        <span class="confidence__label">Confianza:</span>
+        <div class="confidence__bar">
+          <div class="confidence__fill" [style.width.%]="r.confidence * 100"></div>
+        </div>
+        <span class="confidence__value">{{ (r.confidence * 100) | number:'1.0-0' }}%</span>
+      </div>
+
+      @if (r.explanation) {
+        <p class="explanation">{{ r.explanation }}</p>
+      }
+    </header>
+
+    @if (r.suggestedParts.length > 0) {
+      <h2>Piezas sugeridas</h2>
+      <ul class="piezas">
+        @for (p of r.suggestedParts; track p.idProduct) {
+          <li class="pieza">
+            @if (p.image) {
+              <img [src]="p.image" [alt]="p.name" loading="lazy" />
+            }
+            <div class="pieza__info">
+              <h3>{{ p.name }}</h3>
+              @if (p.description) {
+                <p>{{ p.description }}</p>
+              }
+              @if (p.lowRangePrice !== null || p.highRangePrice !== null) {
+                <p class="pieza__precio">
+                  @if (p.lowRangePrice !== null && p.highRangePrice !== null) {
+                    {{ p.lowRangePrice }}€ – {{ p.highRangePrice }}€
+                  } @else if (p.lowRangePrice !== null) {
+                    desde {{ p.lowRangePrice }}€
+                  } @else {
+                    hasta {{ p.highRangePrice }}€
+                  }
+                </p>
+              }
+            </div>
+          </li>
+        }
+      </ul>
+    } @else {
+      <p class="sin-piezas">
+        No se han identificado piezas concretas para reemplazar. Se recomienda revisión profesional.
+      </p>
+    }
+
+    @if (r.unresolvedPartNames.length > 0) {
+      <aside class="aviso">
+        <strong>Aviso:</strong> el asistente sugirió piezas que no figuran en nuestro
+        catálogo y han sido descartadas
+        ({{ r.unresolvedPartNames.join(', ') }}).
+      </aside>
+    }
+
+    <button type="button" class="boton-volver" (click)="volverAHome()">
+      Hacer otro diagnóstico
+    </button>
+
+    <button type="button" class="boton-aceptar" (click)="aceptarDiagnostico()" [disabled]="savingIssue()">
+      {{ savingIssue() ? 'Guardando diagnóstico...' : 'Aceptar diagnóstico y elegir taller' }}
+    </button>
+  }
+</section>

--- a/frontend/src/app/components/diagnostico/diagnostico.ts
+++ b/frontend/src/app/components/diagnostico/diagnostico.ts
@@ -20,160 +20,8 @@ interface DiagnosticoNavState {
   selector: 'app-diagnostico-page',
   standalone: true,
   imports: [CommonModule],
-  template: `
-    <section class="diagnostico-page">
-      @if (successMessage()) {
-        <div class="estado estado--success" role="status" aria-live="polite">
-          <p>{{ successMessage() }}</p>
-        </div>
-      }
-
-      @if (loading()) {
-        <div class="estado estado--loading">
-          <p>Analizando síntomas con el asistente IA…</p>
-        </div>
-      } @else if (errorMessage()) {
-        <div class="estado estado--error">
-          <h2>No se pudo completar el diagnóstico</h2>
-          <p>{{ errorMessage() }}</p>
-          <button type="button" (click)="volverAHome()">Volver</button>
-        </div>
-      } @else if (resultado(); as r) {
-        <header class="cabecera">
-          <h1>Diagnóstico estimado</h1>
-          <p class="diagnosis">{{ r.diagnosis }}</p>
-
-          <div class="confidence" [attr.aria-label]="'Confianza ' + (r.confidence * 100 | number:'1.0-0') + '%'">
-            <span class="confidence__label">Confianza:</span>
-            <div class="confidence__bar">
-              <div class="confidence__fill" [style.width.%]="r.confidence * 100"></div>
-            </div>
-            <span class="confidence__value">{{ (r.confidence * 100) | number:'1.0-0' }}%</span>
-          </div>
-
-          @if (r.explanation) {
-            <p class="explanation">{{ r.explanation }}</p>
-          }
-        </header>
-
-        @if (r.suggestedParts.length > 0) {
-          <h2>Piezas sugeridas</h2>
-          <ul class="piezas">
-            @for (p of r.suggestedParts; track p.idProduct) {
-              <li class="pieza">
-                @if (p.image) {
-                  <img [src]="p.image" [alt]="p.name" loading="lazy" />
-                }
-                <div class="pieza__info">
-                  <h3>{{ p.name }}</h3>
-                  @if (p.description) {
-                    <p>{{ p.description }}</p>
-                  }
-                  @if (p.lowRangePrice !== null || p.highRangePrice !== null) {
-                    <p class="pieza__precio">
-                      @if (p.lowRangePrice !== null && p.highRangePrice !== null) {
-                        {{ p.lowRangePrice }}€ – {{ p.highRangePrice }}€
-                      } @else if (p.lowRangePrice !== null) {
-                        desde {{ p.lowRangePrice }}€
-                      } @else {
-                        hasta {{ p.highRangePrice }}€
-                      }
-                    </p>
-                  }
-                </div>
-              </li>
-            }
-          </ul>
-        } @else {
-          <p class="sin-piezas">
-            No se han identificado piezas concretas para reemplazar. Se recomienda revisión profesional.
-          </p>
-        }
-
-        @if (r.unresolvedPartNames.length > 0) {
-          <aside class="aviso">
-            <strong>Aviso:</strong> el asistente sugirió piezas que no figuran en nuestro
-            catálogo y han sido descartadas
-            ({{ r.unresolvedPartNames.join(', ') }}).
-          </aside>
-        }
-
-        <button type="button" class="boton-volver" (click)="volverAHome()">
-          Hacer otro diagnóstico
-        </button>
-
-        <button type="button" class="boton-aceptar" (click)="aceptarDiagnostico()" [disabled]="savingIssue()">
-          {{ savingIssue() ? 'Guardando diagnóstico...' : 'Aceptar diagnóstico y elegir taller' }}
-        </button>
-      }
-    </section>
-  `,
-  styles: [
-    `
-      :host { display: block; }
-      .diagnostico-page {
-        max-width: 960px;
-        margin: 0 auto;
-        padding: 1.5rem;
-      }
-      .estado { padding: 2rem; text-align: center; }
-      .estado--error { color: #b00020; }
-      .estado--success {
-        color: #1f5e24;
-        background: #e8f5e9;
-        border: 1px solid #a5d6a7;
-        border-radius: 0.4rem;
-        margin-bottom: 1rem;
-        padding: 0.75rem 1rem;
-      }
-      .cabecera h1 { margin: 0 0 0.5rem; }
-      .diagnosis { font-size: 1.15rem; font-weight: 600; margin: 0 0 1rem; }
-      .confidence {
-        display: flex; align-items: center; gap: 0.75rem; margin: 1rem 0;
-      }
-      .confidence__bar {
-        flex: 1; height: 0.6rem; background: #eee; border-radius: 0.3rem; overflow: hidden;
-      }
-      .confidence__fill { height: 100%; background: #2e7d32; transition: width 0.4s; }
-      .explanation { color: #444; line-height: 1.5; }
-      .piezas { list-style: none; padding: 0; display: grid; gap: 1rem;
-        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
-      .pieza {
-        border: 1px solid #ddd; border-radius: 0.5rem; padding: 1rem;
-        display: flex; flex-direction: column; gap: 0.75rem; background: #fff;
-      }
-      .pieza img {
-        width: 100%; height: 160px; object-fit: cover; border-radius: 0.35rem; background: #f5f5f5;
-      }
-      .pieza__info h3 { margin: 0 0 0.25rem; font-size: 1rem; }
-      .pieza__info p { margin: 0; font-size: 0.9rem; color: #555; }
-      .pieza__precio { font-weight: 600; color: #1565c0; }
-      .sin-piezas { color: #555; font-style: italic; }
-      .aviso {
-        margin-top: 1.5rem; padding: 0.75rem 1rem;
-        background: #fff8e1; border-left: 4px solid #f9a825; border-radius: 0.25rem;
-        font-size: 0.9rem;
-      }
-      .boton-volver {
-        margin-top: 2rem; padding: 0.6rem 1.2rem;
-        background: #1565c0; color: white; border: none; border-radius: 0.3rem;
-        cursor: pointer; font-size: 1rem;
-      }
-      .boton-volver:hover { background: #0d47a1; }
-      .boton-aceptar {
-        margin-top: 0.75rem; margin-left: 0.75rem; padding: 0.6rem 1.2rem;
-        background: #2e7d32; color: white; border: none; border-radius: 0.3rem;
-        cursor: pointer; font-size: 1rem;
-      }
-      .boton-aceptar:hover { background: #1f5e24; }
-      .boton-aceptar:disabled { opacity: 0.7; cursor: not-allowed; }
-      /* Dark theme overrides for diagnostico component */
-      :host(.dark) .diagnostico-page {
-        color: #ffffff;
-        background: #1f2937;
-      }
-    `,
-  ],
+  templateUrl: './diagnostico.html',
+  styleUrl: './diagnostico.css',
 })
 export class DiagnosticoComponent implements OnInit {
   private readonly api = inject(AutodiagnosisApiService);
@@ -217,11 +65,6 @@ export class DiagnosticoComponent implements OnInit {
       return;
     }
 
-    if (state.clientId == null || state.personalVehicleId == null) {
-      this.errorMessage.set('No se pudo resolver el cliente o el vehículo seleccionado.');
-      return;
-    }
-
     const payload: AutodiagnosisRequest = {
       clientId: state.clientId,
       personalVehicleId: state.personalVehicleId,
@@ -251,6 +94,11 @@ export class DiagnosticoComponent implements OnInit {
 
   aceptarDiagnostico(): void {
     if (this.savingIssue() || this.payload == null || this.resultado() == null) {
+      return;
+    }
+
+    if (this.payload.clientId == null || this.payload.personalVehicleId == null) {
+      this.errorMessage.set('Para aceptar el diagnóstico y elegir taller, guarda primero tu coche en tu garaje desde el inicio.');
       return;
     }
 

--- a/frontend/src/app/components/home/home.css
+++ b/frontend/src/app/components/home/home.css
@@ -20,38 +20,57 @@
   font-weight: 600;
 }
 
-.home-mis-coches {
+.home-save-vehicle {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  align-items: flex-start;
+  gap: 8px;
   background: #fff;
   border: 1px solid #e1e7ee;
   border-radius: 12px;
-  padding: 12px 16px;
+  padding: 14px 16px;
 }
 
-.home-mis-coches-label {
+.home-save-vehicle-hint {
+  margin: 0;
   font-weight: 600;
   color: #1a6bbd;
   font-size: 0.95rem;
 }
 
-.home-mis-coches-select {
-  padding: 8px 12px;
+.home-save-vehicle-btn {
+  padding: 8px 16px;
   border-radius: 8px;
-  border: 1px solid #b7c3d2;
-  background: #fff;
+  border: 1px solid #1a6bbd;
+  background: #1a6bbd;
+  color: #fff;
+  font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
 }
 
-.home-variant-warning {
-  margin: -2px 0 0;
-  padding: 0.45rem 0.7rem;
-  border-radius: 999px;
-  background: #fffbeb;
-  color: #92400e;
-  border: 1px solid #f59e0b;
-  font-size: 0.86rem;
-  line-height: 1.25;
+.home-save-vehicle-btn:disabled {
+  background: #b7c3d2;
+  border-color: #b7c3d2;
+  cursor: not-allowed;
+}
+
+.home-save-vehicle-sub {
+  margin: 0;
+  color: #555;
+  font-size: 0.85rem;
+}
+
+.home-save-vehicle-success {
+  margin: 0;
+  color: #1f5e24;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.home-save-vehicle-error {
+  margin: 0;
+  color: #b00020;
+  font-weight: 600;
+  font-size: 0.9rem;
 }

--- a/frontend/src/app/components/home/home.html
+++ b/frontend/src/app/components/home/home.html
@@ -6,29 +6,12 @@
   <app-selecciona-problema (problemaChange)="onProblemaChange($event)" />
 
   @if (isLoggedIn && personalVehicles.length > 0) {
-    <div class="home-mis-coches">
-      <label class="home-mis-coches-label" for="home-personal-vehicle">
-        ¿Diagnosticar uno de tus coches?
-      </label>
-      <select
-        id="home-personal-vehicle"
-        class="home-mis-coches-select"
-        [ngModel]="selectedPersonalVehicleId"
-        (ngModelChange)="onPersonalVehicleSelect($event)"
-      >
-        <option [ngValue]="null">— Introducir uno nuevo —</option>
-        @for (vehicle of personalVehicles; track vehicle.id) {
-          <option [ngValue]="vehicle.id">
-            {{ displayName(vehicle) }}@if (vehicle.plate) { · {{ vehicle.plate }} }
-          </option>
-        }
-      </select>
-    </div>
+    <app-selector-mis-vehiculos
+      [vehicles]="personalVehicles"
+      [selectedId]="selectedPersonalVehicleId"
+      (selectionChange)="onPersonalVehicleSelect($event)"
+    />
   }
-
-  <p class="home-variant-warning">
-    La variante específica puede tardar hasta un minuto en cargarse tanto si eliges un coche de "Mis vehículos" como si lo rellenas manualmente.
-  </p>
 
   <app-introducir-vehiculo
     [tieneProblema]="tieneProblema"
@@ -36,4 +19,29 @@
     (vehicleContextChange)="onVehicleContextChange($event)"
     (enviar)="onEnviar()"
   />
+
+  @if (isLoggedIn && selectedPersonalVehicleId === null) {
+    <div class="home-save-vehicle">
+      <p class="home-save-vehicle-hint">
+        ¿Quieres guardar este coche en tu garaje para no rellenar sus datos la próxima vez?
+      </p>
+      <button
+        type="button"
+        class="home-save-vehicle-btn"
+        [disabled]="!canSaveVehicle"
+        (click)="onGuardarCoche()"
+      >
+        @if (savingVehicle) { Guardando... } @else { Guardar coche en mi garaje }
+      </button>
+      @if (!canSaveVehicle && !savingVehicle) {
+        <p class="home-save-vehicle-sub">Selecciona marca, modelo y variante para poder guardarlo.</p>
+      }
+      @if (saveVehicleMessage) {
+        <p class="home-save-vehicle-success">{{ saveVehicleMessage }}</p>
+      }
+      @if (saveVehicleError) {
+        <p class="home-save-vehicle-error">{{ saveVehicleError }}</p>
+      }
+    </div>
+  }
 </section>

--- a/frontend/src/app/components/home/home.ts
+++ b/frontend/src/app/components/home/home.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { IntroducirVehiculo } from '../introducir-vehiculo/introducir-vehiculo';
 import { SeleccionaProblema, ProblemaSeleccion } from '../selecciona-problema/selecciona-problema';
+import { SelectorMisVehiculos } from '../selector-mis-vehiculos/selector-mis-vehiculos';
 import { VehicleSearchContext, PersonalVehicleResponse } from '../../services/api.models';
 import { AuthStateService } from '../../services/auth-state.service';
 import { PersonalVehicleApiService } from '../../services/personal-vehicle-api.service';
@@ -11,7 +12,7 @@ import { PersonalVehicleApiService } from '../../services/personal-vehicle-api.s
 @Component({
   selector: 'app-home-page',
   standalone: true,
-  imports: [CommonModule, FormsModule, IntroducirVehiculo, SeleccionaProblema],
+  imports: [CommonModule, FormsModule, IntroducirVehiculo, SeleccionaProblema, SelectorMisVehiculos],
   templateUrl: './home.html',
   styleUrl: './home.css',
 })
@@ -29,7 +30,9 @@ export class HomeComponent {
   selectedPersonalVehicleId: number | null = null;
   prefillContext: VehicleSearchContext | null = null;
   submitError = '';
-  private creatingVehicle = false;
+  saveVehicleMessage = '';
+  saveVehicleError = '';
+  savingVehicle = false;
 
   get tieneProblema(): boolean {
     return this.seleccion.problemas.length > 0 || !!this.seleccion.descripcionLibre.trim();
@@ -83,6 +86,8 @@ export class HomeComponent {
 
   onPersonalVehicleSelect(id: number | null): void {
     this.submitError = '';
+    this.saveVehicleMessage = '';
+    this.saveVehicleError = '';
     this.selectedPersonalVehicleId = id;
     if (id === null) {
       this.prefillContext = null;
@@ -94,7 +99,23 @@ export class HomeComponent {
 
   onVehicleContextChange(ctx: VehicleSearchContext): void {
     this.submitError = '';
+    this.saveVehicleError = '';
     this.vehicleContext = ctx;
+
+    if (this.selectedPersonalVehicleId !== null && this.divergesFromSelected(ctx)) {
+      this.selectedPersonalVehicleId = null;
+      this.prefillContext = null;
+      this.saveVehicleMessage = '';
+      localStorage.removeItem('selectedPersonalVehicleId');
+    }
+  }
+
+  private divergesFromSelected(ctx: VehicleSearchContext): boolean {
+    const selected = this.personalVehicles.find(v => v.id === this.selectedPersonalVehicleId);
+    if (!selected) return false;
+    return ctx.brand !== selected.brand
+      || ctx.modelId !== selected.vehicleId
+      || ctx.variantId !== selected.vehicleModelId;
   }
 
   onProblemaChange(seleccion: ProblemaSeleccion): void {
@@ -103,15 +124,7 @@ export class HomeComponent {
   }
 
   onEnviar(): void {
-    if (this.creatingVehicle) {
-      return;
-    }
-
     const clientId = this.auth.userId();
-    if (clientId === null) {
-      this.submitError = 'Debes iniciar sesión para enviar el diagnóstico.';
-      return;
-    }
 
     if (this.selectedPersonalVehicleId !== null) {
       this.submitError = '';
@@ -119,22 +132,37 @@ export class HomeComponent {
       return;
     }
 
-    if (this.personalVehicles.length > 0) {
-      this.submitError = 'Selecciona uno de tus coches guardados para continuar.';
-      return;
-    }
-
     const vehicleModelId = this.vehicleContext?.variantId ?? this.vehicleContext?.modelId;
     if (vehicleModelId === null || vehicleModelId === undefined) {
-      this.submitError = 'Indica al menos marca y modelo del coche para guardarlo automáticamente.';
+      this.submitError = 'Indica al menos marca y modelo del coche para enviar el diagnóstico.';
       return;
     }
 
     this.submitError = '';
-    this.creatingVehicle = true;
+    this.navigateToDiagnostico(clientId, null);
+  }
+
+  get canSaveVehicle(): boolean {
+    if (!this.isLoggedIn || this.savingVehicle) return false;
+    if (this.selectedPersonalVehicleId !== null) return false;
+    return this.vehicleContext?.variantId != null;
+  }
+
+  onGuardarCoche(): void {
+    if (!this.canSaveVehicle) return;
+
+    const ownerId = this.auth.userId();
+    const vehicleModelId = this.vehicleContext?.variantId ?? null;
+    if (ownerId === null || vehicleModelId === null) {
+      return;
+    }
+
+    this.saveVehicleError = '';
+    this.saveVehicleMessage = '';
+    this.savingVehicle = true;
 
     this.personalVehicleApi.create({
-      ownerId: clientId,
+      ownerId,
       vehicleModelId,
       plate: null,
       vin: null,
@@ -142,21 +170,20 @@ export class HomeComponent {
     }).subscribe({
       next: (created: PersonalVehicleResponse) => {
         this.personalVehicles = [created, ...this.personalVehicles];
-        this.selectedPersonalVehicleId = created.id;
-        localStorage.setItem('selectedPersonalVehicleId', String(created.id));
-        this.creatingVehicle = false;
+        this.savingVehicle = false;
+        this.saveVehicleMessage = 'Coche guardado en tu garaje. Ya puedes seleccionarlo de la lista.';
+        this.applyPersonalVehicle(created.id);
         this.cdr.detectChanges();
-        this.navigateToDiagnostico(clientId, created.id);
       },
       error: () => {
-        this.creatingVehicle = false;
-        this.submitError = 'No se pudo guardar tu coche automáticamente. Revísalo en Mis Vehículos e inténtalo de nuevo.';
+        this.savingVehicle = false;
+        this.saveVehicleError = 'No se pudo guardar el coche. Inténtalo de nuevo.';
         this.cdr.detectChanges();
       },
     });
   }
 
-  private navigateToDiagnostico(clientId: number, personalVehicleId: number): void {
+  private navigateToDiagnostico(clientId: number | null, personalVehicleId: number | null): void {
     this.router.navigate(['/diagnostico'], {
       state: {
         vehicle: this.vehicleContext,
@@ -167,11 +194,6 @@ export class HomeComponent {
     });
   }
 
-  displayName(v: PersonalVehicleResponse): string {
-    const parts = [v.brand, v.vehicleName, v.modelName].filter(Boolean);
-    return parts.length > 0 ? parts.join(' ') : `Vehículo #${v.id}`;
-  }
-
   private applyPersonalVehicle(id: number): void {
     const vehicle = this.personalVehicles.find(v => v.id === id);
     if (!vehicle) return;
@@ -179,7 +201,7 @@ export class HomeComponent {
     localStorage.setItem('selectedPersonalVehicleId', String(id));
     const selectedContext: VehicleSearchContext = {
       brand: vehicle.brand,
-      modelId: null,
+      modelId: vehicle.vehicleId,
       modelName: vehicle.vehicleName,
       variantId: vehicle.vehicleModelId,
       variantName: vehicle.modelName,

--- a/frontend/src/app/components/introducir-vehiculo/introducir-vehiculo.ts
+++ b/frontend/src/app/components/introducir-vehiculo/introducir-vehiculo.ts
@@ -271,25 +271,7 @@ export class IntroducirVehiculo implements OnInit, OnDestroy, OnChanges {
       this.models = models;
       this.loadingModels = false;
 
-      let resolvedModelId = ctx.modelId;
-
-      if (!resolvedModelId && ctx.modelName) {
-        const normalize = (value: string) => value.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
-        const normalizedModelName = normalize(ctx.modelName);
-        const modelByName = models.find((model) => {
-          const candidate = normalize(model.name);
-          return candidate === normalizedModelName
-            || candidate.includes(normalizedModelName)
-            || normalizedModelName.includes(candidate);
-        });
-        if (modelByName) {
-          resolvedModelId = modelByName.id;
-        }
-      }
-
-      if (!resolvedModelId && ctx.variantId) {
-        resolvedModelId = await this.findModelIdByVariantId(ctx.variantId, models);
-      }
+      const resolvedModelId = ctx.modelId ?? this.matchModelByName(ctx.modelName, models);
 
       if (resolvedModelId) {
         this.selectedModelId = resolvedModelId;
@@ -316,21 +298,18 @@ export class IntroducirVehiculo implements OnInit, OnDestroy, OnChanges {
     this.cdr.detectChanges();
   }
 
-  private async findModelIdByVariantId(
-    variantId: number,
+  private matchModelByName(
+    modelName: string | null | undefined,
     models: VehicleModelSummary[],
-  ): Promise<number | null> {
-    const checkedModels = await Promise.all(
-      models.map(async (model) => {
-        const variants = await firstValueFrom(this.vehicleApi.getVariants(model.id));
-        return {
-          modelId: model.id,
-          hasVariant: variants.some((variant) => variant.id === variantId),
-        };
-      }),
-    );
-
-    return checkedModels.find((model) => model.hasVariant)?.modelId ?? null;
+  ): number | null {
+    if (!modelName) return null;
+    const normalize = (value: string) => value.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+    const target = normalize(modelName);
+    const found = models.find((model) => {
+      const candidate = normalize(model.name);
+      return candidate === target || candidate.includes(target) || target.includes(candidate);
+    });
+    return found?.id ?? null;
   }
 
   private emitContext(): void {

--- a/frontend/src/app/components/selector-mis-vehiculos/selector-mis-vehiculos.css
+++ b/frontend/src/app/components/selector-mis-vehiculos/selector-mis-vehiculos.css
@@ -1,0 +1,24 @@
+.smv-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: #fff;
+  border: 1px solid #e1e7ee;
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.smv-label {
+  font-weight: 600;
+  color: #1a6bbd;
+  font-size: 0.95rem;
+}
+
+.smv-select {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #b7c3d2;
+  background: #fff;
+  font-size: 0.95rem;
+  cursor: pointer;
+}

--- a/frontend/src/app/components/selector-mis-vehiculos/selector-mis-vehiculos.html
+++ b/frontend/src/app/components/selector-mis-vehiculos/selector-mis-vehiculos.html
@@ -1,0 +1,18 @@
+<div class="smv-card">
+  <label class="smv-label" for="smv-select">
+    ¿Diagnosticar uno de tus coches?
+  </label>
+  <select
+    id="smv-select"
+    class="smv-select"
+    [ngModel]="selectedId"
+    (ngModelChange)="onChange($event)"
+  >
+    <option [ngValue]="null">— Introducir uno nuevo —</option>
+    @for (vehicle of vehicles; track vehicle.id) {
+      <option [ngValue]="vehicle.id">
+        {{ displayName(vehicle) }}@if (vehicle.plate) { · {{ vehicle.plate }} }
+      </option>
+    }
+  </select>
+</div>

--- a/frontend/src/app/components/selector-mis-vehiculos/selector-mis-vehiculos.ts
+++ b/frontend/src/app/components/selector-mis-vehiculos/selector-mis-vehiculos.ts
@@ -1,0 +1,26 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { PersonalVehicleResponse } from '../../services/api.models';
+
+@Component({
+  selector: 'app-selector-mis-vehiculos',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './selector-mis-vehiculos.html',
+  styleUrl: './selector-mis-vehiculos.css',
+})
+export class SelectorMisVehiculos {
+  @Input() vehicles: PersonalVehicleResponse[] = [];
+  @Input() selectedId: number | null = null;
+  @Output() selectionChange = new EventEmitter<number | null>();
+
+  displayName(v: PersonalVehicleResponse): string {
+    const parts = [v.brand, v.vehicleName, v.modelName].filter(Boolean);
+    return parts.length > 0 ? parts.join(' ') : `Vehículo #${v.id}`;
+  }
+
+  onChange(id: number | null): void {
+    this.selectionChange.emit(id);
+  }
+}

--- a/frontend/src/app/components/shared/footer/footer.html
+++ b/frontend/src/app/components/shared/footer/footer.html
@@ -36,7 +36,6 @@
       <div class="footer-col">
         <h3 class="footer-col-title">Servicios</h3>
         <ul class="footer-links">
-          <li><a routerLink="/diagnostico" class="footer-link">Diagnóstico de vehículos</a></li>
           <li><a routerLink="/taller"      class="footer-link">Buscar taller</a></li>
 
           @if (authStateService.canAccessSeguimiento()) {

--- a/frontend/src/app/components/shared/header/header.html
+++ b/frontend/src/app/components/shared/header/header.html
@@ -126,15 +126,6 @@
         </svg>
         Inicio
       </a>
-      <a routerLink="/diagnostico" routerLinkActive="nav-item--active" class="nav-item">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-          aria-hidden="true">
-          <circle cx="12" cy="12" r="10" />
-          <line x1="12" y1="8" x2="12" y2="12" />
-          <line x1="12" y1="16" x2="12.01" y2="16" />
-        </svg>
-        Diagnóstico
-      </a>
       <a routerLink="/taller" routerLinkActive="nav-item--active" class="nav-item">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           aria-hidden="true">
@@ -179,7 +170,6 @@
       }
       @if (authStateService.role() === 'USER') {
         <a routerLink="/home" class="mobile-nav-link" (click)="toggleMobileMenu()">Inicio</a>
-        <a routerLink="/diagnostico" class="mobile-nav-link" (click)="toggleMobileMenu()">Diagnóstico</a>
         <a routerLink="/taller" class="mobile-nav-link" (click)="toggleMobileMenu()">Taller</a>
         @if (authStateService.canAccessSeguimiento()) {
           <a routerLink="/usuario/seguimiento" class="mobile-nav-link" (click)="toggleMobileMenu()">Seguimiento</a>

--- a/frontend/src/app/services/api.models.ts
+++ b/frontend/src/app/services/api.models.ts
@@ -180,8 +180,8 @@ export interface VehicleSearchContext {
 // ── Autodiagnóstico (IA) ───────────────────────────────────────────────────
 
 export interface AutodiagnosisRequest {
-  clientId: number;
-  personalVehicleId: number;
+  clientId: number | null;
+  personalVehicleId: number | null;
   vehicleModelId: number;
   symptoms: string[];
   freeText: string;
@@ -211,6 +211,7 @@ export interface PersonalVehicleResponse {
   id: number;
   ownerId: number;
   vehicleModelId: number;
+  vehicleId: number | null;
   brand: string | null;
   vehicleName: string | null;
   modelName: string | null;


### PR DESCRIPTION
Conjunto de mejoras enfocadas en el flujo del inicio y la pantalla de diagnóstico:

- **Inicio**: botón explícito "Guardar coche en mi garaje" sustituyendo el autoguardado silencioso. Diagnosticar sigue funcionando sin guardar (el guardado es opcional). Si el usuario edita el formulario tras seleccionar un coche guardado, se deselecciona automáticamente para evitar estados inconsistentes.
- **Selector de "Mis vehículos"** extraído a componente independiente (`selector-mis-vehiculos`).
- **Perf**: optimizadas las queries de catálogo de vehículos. Antes `VehicleServiceImpl` hacía `findAll()` + filter en memoria; ahora usa queries derivadas con `WHERE`/`DISTINCT`. La carga de variantes pasa de decenas de segundos a milisegundos.
- **Backend**: añadido `vehicleId` (id del `Vehicle` padre) al `PersonalVehicleResponseDTO`, eliminando un brute-force scan que hacía el frontend para resolver el modelo padre desde la variante.
- **Fix `sessionUuid`**: el `Issue` ahora genera `sessionUuid` desde su creación en `IssueService.createDraftIssue` en lugar de en la selección de taller. Resuelve el 500 al aceptar diagnóstico.
- **Header/footer**: eliminado el enlace navegable a `/diagnostico` porque era un destino de transición (necesita state desde `home`), no una página accesible directamente. La ruta se conserva.
- **Refactor**: separados template y estilos de `DiagnosticoComponent` en archivos independientes (`.html`/`.css`).