### PR TITLE
docs: Documentando el proyecto entero

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 ISMAEL FERNÁNDEZ MÉNDEZ
+Copyright (c) 2026 Autodiagnóstico de Vehículos - Universidad de Almería
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10,7 +10,10 @@ copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+copies or substantial portions of the Software. In particular, when redistributing
+or publishing derivative works, please include an attribution statement that
+credits "Autodiagnóstico de Vehículos - Universidad de Almería" as the original
+project authors.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Nuestra arquitectura se basa en un stack moderno y eficiente:
 *   <img src="https://img.shields.io/badge/MySQL-4479A1?style=flat-square&logo=mysql&logoColor=white" /> **Persistencia**: MySQL se encarga del almacenamiento y gestión de los datos.
 
 ---
+## 📚 Documentación
+La documentación técnica y guías están en la carpeta `documentacion`. Empieza por: [documentacion/README.md](documentacion/README.md)
+
 <p align="center">
   <b>© 2026 - Universidad de Almería</b>
 </p>

--- a/documentacion/README.md
+++ b/documentacion/README.md
@@ -9,5 +9,6 @@ En esta carpeta se agrupan las guías y la documentación técnica del proyecto.
 - **Flujo frontend↔backend**: [flujo-frontend-backend.md](flujo-frontend-backend.md)
 - **MCP / IA ↔ Backend**: [mcp-flujo-ia-backend.md](mcp-flujo-ia-backend.md)
 - **Datos / Scraping**: [data/scraping-coches.md](data/scraping-coches.md)
+- **Docker Compose**: [docker-compose.md](docker-compose.md)
 
 Para contribuciones: añade o actualiza archivos en esta carpeta y crea enlaces desde `componentes/index.md` o `indice-por-flujo.md` según corresponda.

--- a/documentacion/README.md
+++ b/documentacion/README.md
@@ -1,0 +1,13 @@
+# Documentación del proyecto
+
+En esta carpeta se agrupan las guías y la documentación técnica del proyecto.
+
+- **Índice por flujo**: [indice-por-flujo.md](indice-por-flujo.md) — guía organizada por flujos funcionales.
+- **Componentes**: [componentes/index.md](componentes/index.md) — índice por componente.
+- **Modelos de datos**: [modelos-datos.md](modelos-datos.md)
+- **API**: [api/api-tracking.md](api/api-tracking.md)
+- **Flujo frontend↔backend**: [flujo-frontend-backend.md](flujo-frontend-backend.md)
+- **MCP / IA ↔ Backend**: [mcp-flujo-ia-backend.md](mcp-flujo-ia-backend.md)
+- **Datos / Scraping**: [data/scraping-coches.md](data/scraping-coches.md)
+
+Para contribuciones: añade o actualiza archivos en esta carpeta y crea enlaces desde `componentes/index.md` o `indice-por-flujo.md` según corresponda.

--- a/documentacion/api/api-tracking.md
+++ b/documentacion/api/api-tracking.md
@@ -1,79 +1,364 @@
-# API Seguimiento y Chat
+# API del backend
+
+Guía de referencia de los endpoints REST del backend de Autodiagnóstico 26.
 
 ## Base URL
 
+En local, todos los controladores cuelgan de:
+
 ```txt
-/api/mechanic
+/api
+```
+
+## Formato de error
+
+La capa global de errores devuelve respuestas con esta estructura:
+
+```json
+{
+  "timestamp": "2026-05-27T19:30:00",
+  "status": 400,
+  "error": "Bad Request",
+  "message": "La solicitud contiene datos invalidos"
+}
+```
+
+Los errores de validación (`@Valid`) y `IllegalArgumentException` devuelven `400`. Los errores del asistente IA o del servidor MCP se traducen normalmente a `502` o `503`.
+
+---
+
+## Autenticación
+
+### `POST /api/auth/register`
+
+Crea un usuario nuevo.
+
+#### Body
+
+```json
+{
+  "fullName": "Ana Perez",
+  "email": "ana@example.com",
+  "password": "secreta123",
+  "role": "USER"
+}
+```
+
+#### Respuesta
+
+`201 Created` con `AuthUserResponseDTO`.
+
+Campos principales:
+
+- `id`
+- `fullName`
+- `email`
+- `role`
+- `avatarUrl`
+- `createdAt`
+- `city`
+- `postalCode`
+
+### `POST /api/auth/login`
+
+Inicia sesión con email y contraseña.
+
+#### Body
+
+```json
+{
+  "email": "ana@example.com",
+  "password": "secreta123"
+}
+```
+
+#### Respuesta
+
+`200 OK` con `AuthUserResponseDTO`.
+
+---
+
+## Usuarios
+
+### `GET /api/users`
+
+Lista todos los usuarios.
+
+### `GET /api/users/{id}`
+
+Devuelve un usuario por ID.
+
+### `PUT /api/users/{id}`
+
+Actualiza datos de perfil.
+
+#### Body
+
+```json
+{
+  "fullName": "Ana Perez",
+  "email": "ana@example.com",
+  "city": "Almeria",
+  "postalCode": "04001"
+}
+```
+
+### `PUT /api/users/{id}/password`
+
+Actualiza la contraseña.
+
+#### Body
+
+```json
+{
+  "currentPassword": "vieja123",
+  "newPassword": "nueva123"
+}
+```
+
+### `POST /api/users/{id}/avatar`
+
+Sube un avatar en `multipart/form-data`.
+
+#### Form field
+
+- `file`
+
+#### Respuesta
+
+```json
+{
+  "avatarUrl": "data:image/png;base64,..."
+}
+```
+
+### `DELETE /api/users/{id}`
+
+Elimina un usuario.
+
+### `PUT /api/users/{id}/role`
+
+Actualiza el rol del usuario.
+
+#### Body
+
+```json
+{
+  "role": "ADMIN"
+}
 ```
 
 ---
 
-# Obtener clientes del mecánico
+## Vehículos
 
-## Endpoint
+### `GET /api/vehicles/brands`
 
-```http
-GET /api/mechanic/{mechanicId}/clients
-```
+Devuelve la lista de marcas disponibles.
 
-## Retorna
+### `GET /api/vehicles/brands/{brand}/models`
+
+Devuelve los modelos de una marca.
+
+#### Respuesta
+
+Lista de `VehicleModelSummaryDTO`:
 
 ```json
 [
-  {
-    "clientId": 11,
-    "sessionUuid": "uuid"
-  }
+  { "id": 1, "name": "Ibiza" }
 ]
 ```
 
----
+### `GET /api/vehicles/{vehicleId}/variants`
 
-# Obtener tracking de cliente
+Devuelve las variantes de un vehículo.
 
-## Endpoint
+#### Respuesta
 
-```http
-GET /api/mechanic/client/{clientId}/tracking
-```
-
-## Uso
-
-Frontend usuario.
+Lista de `VehicleVariantDTO` con campos como `id`, `modelName`, `transmission`, `engineName` y `engineType`.
 
 ---
 
-# Respuesta
+## Vehículos personales
+
+### `GET /api/personal-vehicles?ownerId={ownerId}`
+
+Lista los vehículos del propietario.
+
+### `GET /api/personal-vehicles/{id}`
+
+Devuelve un vehículo personal por ID.
+
+### `POST /api/personal-vehicles`
+
+Crea un vehículo personal.
+
+#### Body
+
+`CreatePersonalVehicleRequestDTO`.
+
+### `DELETE /api/personal-vehicles/{id}?ownerId={ownerId}`
+
+Elimina un vehículo personal validando el propietario.
+
+---
+
+## Talleres y solicitudes
+
+### `GET /api/workshops`
+
+Lista talleres. El query `clientId` es opcional y se usa para marcar selección del cliente.
+
+### `GET /api/workshops/{workshopId}?clientId={clientId}`
+
+Devuelve un taller concreto.
+
+### `POST /api/workshops/{workshopId}/select`
+
+Selecciona un taller para un cliente.
+
+#### Body
 
 ```json
 {
   "clientId": 11,
-  "sessionUuid": "uuid",
-  "status": "rojo"
+  "personalVehicleId": 25,
+  "description": "El coche hace ruido al arrancar"
 }
 ```
 
----
+#### Respuesta
 
-# Si no existe tracking
+`WorkshopSelectionResponseDTO` con:
 
-Retorna:
+- `workshop`
+- `tracking`
 
-```http
-404 Not Found
+### `GET /api/workshops/exists-for-mechanic/{mechanicId}`
+
+Comprueba si existe un taller asociado al mecánico.
+
+#### Respuesta
+
+```json
+{
+  "exists": true
+}
 ```
 
----
+### `POST /api/workshop-applications`
 
-# Actualizar estado cliente
+Envía una solicitud para crear un taller.
 
-## Endpoint
+#### Body
 
-```http
-POST /api/mechanic/{mechanicId}/clients/{clientId}/status
+```json
+{
+  "fullName": "Mecanica Lopez",
+  "email": "taller@example.com",
+  "password": "secreta123",
+  "workshopName": "Taller Lopez",
+  "address": "Calle Falsa 123",
+  "phone": "600000000",
+  "schedule": "L-V 9:00-18:00",
+  "photoUrl": "https://...",
+  "vehicleLimit": 4,
+  "latitude": 36.84,
+  "longitude": -2.46
+}
 ```
 
-## Body
+#### Respuesta
+
+`WorkshopApplicationResponseDTO` con datos de la solicitud y su estado.
+
+### `GET /api/workshop-applications/pending`
+
+Lista solicitudes pendientes.
+
+### `POST /api/workshop-applications/{applicationId}/approve`
+
+Aproba una solicitud y crea el taller/mecánico asociado.
+
+### `POST /api/workshop-applications/{applicationId}/reject`
+
+Rechaza una solicitud.
+
+### `DELETE /api/workshop-applications/workshops/{workshopId}`
+
+Elimina un taller aprobado.
+
+---
+
+## Autodiagnóstico e issues
+
+### `POST /api/autodiagnosis/diagnose`
+
+Ejecuta el autodiagnóstico sin persistir el issue.
+
+#### Body
+
+```json
+{
+  "clientId": 11,
+  "personalVehicleId": 25,
+  "vehicleModelId": 7,
+  "symptoms": ["ruido al arrancar", "vibracion"],
+  "freeText": "Se oye un golpe al acelerar",
+  "year": 2018,
+  "engineType": "GASOLINE",
+  "transmission": "MANUAL"
+}
+```
+
+#### Respuesta
+
+`AutodiagnosisResponseDTO`:
+
+- `diagnosis`
+- `confidence`
+- `explanation`
+- `suggestedParts`
+- `unresolvedPartNames`
+
+### `POST /api/issues`
+
+Crea el issue borrador a partir del mismo payload de autodiagnóstico.
+
+#### Body
+
+`AutodiagnosisRequestDTO`.
+
+#### Respuesta
+
+`AutodiagnosisResponseDTO`.
+
+---
+
+## Seguimiento del mecánico
+
+### `GET /api/mechanic/{mechanicId}/clients`
+
+Devuelve los clientes del mecánico.
+
+#### Respuesta
+
+Lista de `MechanicClientDTO`.
+
+### `GET /api/mechanic/client/{clientId}/trackings`
+
+Devuelve los seguimientos de un cliente.
+
+### `GET /api/mechanic/tracking/{sessionUuid}`
+
+Devuelve un tracking concreto por `sessionUuid`.
+
+### `POST /api/mechanic/{mechanicId}/tracking/{sessionUuid}/status`
+
+Actualiza el estado del tracking.
+
+#### Body
 
 ```json
 {
@@ -81,95 +366,175 @@ POST /api/mechanic/{mechanicId}/clients/{clientId}/status
 }
 ```
 
+### `POST /api/mechanic/{mechanicId}/tracking/{sessionUuid}/tracking-update`
+
+Actualiza el último mensaje del seguimiento.
+
+#### Body
+
+```json
+{
+  "message": "Se ha pedido la pieza y llega mañana"
+}
+```
+
+#### Campos clave de `MechanicClientDTO`
+
+- `clientId`
+- `workshopId`
+- `mechanicId`
+- `problemDescription`
+- `aiDiagnosis`
+- `recommendedParts`
+- `latestUpdate`
+- `status`
+- `sessionUuid`
+- `issueId`
+
 ---
 
-# Actualizar mensaje seguimiento
+## Chat
 
-## Endpoint
+El chat se identifica por `sessionUuid`. No depende del login, sino de la sesión de seguimiento asociada al issue.
 
-```http
-POST /api/mechanic/{mechanicId}/clients/{clientId}/tracking-update
+### `POST /api/chat/join?sessionUuid={sessionUuid}&participantId={participantId}`
+
+Entrar a una sala.
+
+#### Respuesta
+
+`ChatJoinResponseDTO` con:
+
+- `sessionUuid`
+- `participantId`
+- `activeUsers`
+- `maxUsers`
+- `joined`
+
+### `POST /api/chat/leave?sessionUuid={sessionUuid}&participantId={participantId}`
+
+Salir de la sala.
+
+### `GET /api/chat/mensajes?sessionUuid={sessionUuid}&limit=50&afterId={afterId}`
+
+Lista mensajes de una sesión.
+
+### `POST /api/chat/mensajes`
+
+Envía un mensaje.
+
+#### Body
+
+```json
+{
+  "participantId": 11,
+  "senderRole": "USER",
+  "sessionUuid": "uuid",
+  "commentText": "Hola, ¿qué tal va el coche?"
+}
+```
+
+#### Respuesta
+
+`ChatMessageResponseDTO` con:
+
+- `id`
+- `participantId`
+- `sessionUuid`
+- `senderRole`
+- `commentText`
+- `wordCount`
+- `readByUser`
+- `createdAt`
+
+### `GET /api/chat/unread?sessionUuid={sessionUuid}`
+
+Devuelve el total de mensajes no leídos.
+
+### `POST /api/chat/mark-read?sessionUuid={sessionUuid}`
+
+Marca como leídos los mensajes de la sesión para el usuario actual.
+
+### `GET /api/chat/presence?sessionUuid={sessionUuid}&participantId={participantId}`
+
+Comprueba si un participante está online en la sala.
+
+---
+
+## Contacto
+
+### `POST /api/contact`
+
+Envía un mensaje de contacto público.
+
+#### Body
+
+```json
+{
+  "name": "Ana Perez",
+  "email": "ana@example.com",
+  "phone": "600000000",
+  "message": "Necesito ayuda con mi coche",
+  "workshopId": 3
+}
+```
+
+### `GET /api/admin/contact`
+
+Lista todos los mensajes de contacto para administración.
+
+### `POST /api/admin/contact/{id}/reply`
+
+Responde a un mensaje de contacto.
+
+#### Body
+
+```json
+{
+  "message": "Gracias por escribirnos, te contestamos en breve"
+}
 ```
 
 ---
 
-# Chat API
+## Geolocalización
 
-## joinRoom
+### `GET /api/geolocation`
 
-```http
-POST /chat/join
+Devuelve una posición aproximada para el cliente.
+
+#### Respuesta
+
+```json
+{
+  "lat": 40.416775,
+  "lng": -3.70379
+}
 ```
 
----
-
-# listMessages
-
-```http
-GET /chat/messages
-```
+Si el servicio externo falla, el backend devuelve un fallback fijo.
 
 ---
 
-# sendMessage
+## Resumen rápido de modelos
 
-```http
-POST /chat/send
-```
-
----
-
-# unreadCount
-
-```http
-GET /chat/unread-count
-```
+- `AuthUserResponseDTO`: usuario autenticado o listado de usuarios.
+- `WorkshopDTO`: ficha del taller, mecánico asociado, estado de selección y vehículos en reparación.
+- `WorkshopApplicationResponseDTO`: solicitud de alta de taller y su estado.
+- `PersonalVehicleResponseDTO`: vehículo registrado por un usuario.
+- `MechanicClientDTO`: seguimiento completo de un cliente/sesión.
+- `ChatMessageRequestDTO` / `ChatMessageResponseDTO`: entrada y salida del chat.
+- `AutodiagnosisRequestDTO` / `AutodiagnosisResponseDTO`: entrada y salida del motor de diagnóstico.
 
 ---
 
-# Modelos principales
+## Nota funcional
 
-## TallerAssignment
+El identificador que une seguimiento, chat y estado del caso es `sessionUuid`.
 
-Contiene:
+Ese UUID es el hilo conductor entre:
 
-- mechanicId
-- clientId
-- sessionUuid
-- latestUpdate
-- status
-
----
-
-# ChatMessage
-
-Contiene:
-
-- sessionUuid
-- senderRole
-- commentText
-- createdAt
-
----
-
-# Arquitectura
-
-El backend usa:
-
-- Spring Boot
-- JPA/Hibernate
-- MySQL
-- DTOs
-- REST API
-
----
-
-# Persistencia
-
-La sesión del chat depende de:
-
-```txt
-sessionUuid
-```
-
-NO del login.
+- issue creado por autodiagnóstico
+- tracking del mecánico
+- sala de chat
+- mensajes leídos/no leídos

--- a/documentacion/componentes/admin.md
+++ b/documentacion/componentes/admin.md
@@ -1,108 +1,87 @@
-# Documentación: Módulo Admin
+# Módulo Admin
 
-Resumen: descripción del área de administración del proyecto, APIs backend, rutas y componentes frontend, modelos de datos y flujos operativos (gestión de usuarios, gestión de talleres y buzón de contacto).
+Resumen del área de administración del proyecto: dashboard, gestión de usuarios, gestión de talleres y buzón de contacto.
 
 ## Propósito
 
-- Proveer herramientas administrativas para gestionar cuentas, talleres y comunicaciones desde una interfaz protegida para roles `ADMIN`.
+- Proveer herramientas administrativas para gestionar cuentas, talleres y comunicaciones desde una interfaz protegida para el rol `ADMIN`.
 
 ## Estructura del frontend
 
-- Dashboard: `frontend/src/app/admin/admin.component.*` — acceso rápido a submódulos.
-- Gestión Usuarios: `frontend/src/app/admin/admin-gestionusuarios/*` — lista, filtros, eliminación.
-- Gestión Talleres: `frontend/src/app/admin/admin-gestiontaller/*` — solicitudes, aprobaciones, talleres activos.
-- Buzón de contacto: `frontend/src/app/admin/admin-contacto/*` — listar mensajes y responder.
+- Dashboard: `frontend/src/app/admin/admin.component.*`
+- Gestión de usuarios: `frontend/src/app/admin/admin-gestionusuarios/*`
+- Gestión de talleres: `frontend/src/app/admin/admin-gestiontaller/*`
+- Buzón de contacto: `frontend/src/app/admin/admin-contacto/*`
 
-### Rutas relevantes
+## Rutas relevantes
 
-- `/admin` → AdminComponent (dashboard) — `canActivate: [adminGuard]`.
-- `/admin/usuarios` → AdminGestionUsuariosComponent (lazy-loaded) — `canActivate: [adminGuard]`.
-- `/admin/gestiontaller` → AdminGestionTallerComponent (lazy-loaded) — `canActivate: [adminGuard]`.
-- `/admin/contacto` → AdminContactoComponent (lazy-loaded) — `canActivate: [adminGuard]`.
+- `/admin` → `AdminComponent`
+- `/admin/usuarios` → `AdminGestionUsuariosComponent`
+- `/admin/gestiontaller` → `AdminGestionTallerComponent`
+- `/admin/contacto` → `AdminContactoComponent`
 
-### Patrón de componentes
+Todas las rutas están protegidas por `adminGuard`.
 
-- Standalone components con `imports: [...]` (CommonModule, FormsModule, RouterLink, etc.).
-- Uso de `signals`/`computed` para estado local (ej.: `users`, `loading`, `error`).
-- Operaciones principales expuestas en TS: `loadUsers()`, `deleteUser()`, `loadPending()`, `approve()`, `reject()`, `loadWorkshops()`, `reply()`.
+## Comportamiento del frontend
 
-## Backend (API)
+- Los componentes son standalone.
+- La gestión de usuarios usa `signals` y `computed` para búsqueda y filtros por rol.
+- La gestión de contacto usa un modal de respuesta.
+- La gestión de talleres muestra solicitudes pendientes, talleres aprobados y acciones de borrado.
 
-Las rutas están protegidas por autenticación y autorización; solo usuarios con rol `ADMIN` deben poder ejecutar estos endpoints.
+## Backend real asociado
 
 ### Usuarios
 
-- GET `/api/users` — listar usuarios
-  - Query: opcional `role=USER|TALLER|ADMIN`, `q=texto` (busqueda)
-  - Response 200: JSON[] de usuarios
-- DELETE `/api/users/{id}` — eliminar cuenta
-  - Auth: ADMIN
-  - Response 204 No Content
+- `GET /api/users`
+- `GET /api/users/{id}`
+- `PUT /api/users/{id}`
+- `PUT /api/users/{id}/password`
+- `POST /api/users/{id}/avatar`
+- `DELETE /api/users/{id}`
+- `PUT /api/users/{id}/role`
 
-Ejemplo (curl):
+### Talleres y solicitudes
 
-```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  -X DELETE https://api.example.com/api/users/123
-```
+- `GET /api/workshops`
+- `GET /api/workshop-applications/pending`
+- `POST /api/workshop-applications/{applicationId}/approve`
+- `POST /api/workshop-applications/{applicationId}/reject`
+- `DELETE /api/workshop-applications/workshops/{workshopId}`
 
-### Talleres y Solicitudes
+### Contacto
 
-- GET `/api/workshops` — lista de talleres (activos)
-- GET `/api/workshop-applications/pending` — solicitudes pendientes
-- POST `/api/workshop-applications/{id}/approve` — aprobar solicitud
-- POST `/api/workshop-applications/{id}/reject` — rechazar solicitud
-- DELETE `/api/workshops/{id}` — eliminar taller
+- `POST /api/contact`
+- `GET /api/admin/contact`
+- `POST /api/admin/contact/{id}/reply`
 
-Response: estandar JSON con entidad o mensaje; códigos 200/204/404 según caso.
+## Modelos principales
 
-### Buzón de contacto
+- `AuthUserResponseDTO`
+- `WorkshopApplicationResponseDTO`
+- `WorkshopDTO`
+- `ContactMessageDTO`
 
-- GET `/api/contact/messages` — listar mensajes
-- POST `/api/contact/messages/{id}/reply` — enviar respuesta desde admin
+## Flujo UI → API
 
-Payload reply:
+### Eliminar usuario
 
-```json
-{ "message": "Gracias por contactarnos. ..." }
-```
+1. `AdminGestionUsuariosComponent` carga la lista con `UserApiService.listUsers()`.
+2. El admin confirma el borrado.
+3. El frontend llama a `UserApiService.deleteAccount(user.id)`.
+4. El backend responde `204 No Content` y el componente recarga la lista.
 
-## Modelos principales (resumen)
+### Gestionar talleres
 
-- User
+1. `AdminGestionTallerComponent` carga solicitudes pendientes y talleres.
+2. El admin aprueba o rechaza la solicitud.
+3. El backend crea o actualiza el taller según el estado.
 
-  - id: number
-  - fullName: string
-  - email: string
-  - role: 'USER' | 'TALLER' | 'ADMIN'
-  - city?: string
-  - postalCode?: string
-  - createdAt: string (ISO)
-- Workshop
+### Responder contacto
 
-  - id: number
-  - name: string
-  - mechanicName: string
-  - address, phone, schedule
-  - vehicleLimit: number
-  - activeVehicles: number
-- WorkshopApplication
-
-  - id, workshopName, fullName, email, address, phone, schedule, vehicleLimit
-- ContactMessage
-
-  - id, name, email, phone?, message, repliedAt?, replyMessage?
-
-## Flujo UI → API (ejemplos)
-
-- Eliminar usuario (frontend):
-  1. AdminGestionUsuariosComponent muestra lista (`loadUsers()` llama `UserApiService.listUsers()`).
-
-2. Usuario hace click en `Eliminar`.
-3. Se pide confirmación por `window.confirm` y luego `userApi.deleteAccount(user.id)`.
-4. Backend responde 204 → componente recarga lista (`loadUsers()`) y muestra toast/error.
-
-Mermaid sequence diagram:
+1. `AdminContactoComponent` lista mensajes con `ContactApiService.listMessages()`.
+2. El admin abre el modal de respuesta.
+3. El frontend llama a `ContactApiService.reply(id, { message })`.
 
 ```mermaid
 sequenceDiagram
@@ -111,13 +90,6 @@ sequenceDiagram
   participant DB
   AdminUI->>API: DELETE /api/users/{id}
   API->>DB: delete user
-  DB-->>API: 204 OK
-  API-->>AdminUI: 204 No Content
-  AdminUI->>AdminUI: reload users
+  DB-->>API: 204 No Content
+  API-->>AdminUI: refresh list
 ```
-
-- Aprobar solicitud taller:
-  1. AdminGestionTallerComponent carga `listPending()` y `listWorkshops()`.
-
-2. Admin pulsa `Aceptar` en solicitud → `applicationService.approve(id)`.
-3. Backend crea/activa taller, borra o marca solicitud, devuelve 200 → frontend recarga datos.

--- a/documentacion/componentes/cambiar-rol.md
+++ b/documentacion/componentes/cambiar-rol.md
@@ -1,0 +1,25 @@
+# Cambiar rol
+
+Esta pantalla permite que un usuario normal pase a rol `TALLER` antes de solicitar el alta de su taller.
+
+## Componente principal
+
+- `CambiarRolComponent` en `frontend/src/app/components/cambiar-rol/`
+
+## Flujo de uso
+
+1. El usuario entra en `/cambiar-rol`.
+2. El componente comprueba si ya es `TALLER`.
+3. Si no lo es, llama a `PUT /api/users/{id}/role` con `{ "role": "TALLER" }`.
+4. El backend devuelve el usuario actualizado.
+5. El frontend actualiza la sesión local con el nuevo rol.
+6. Tras un pequeño retardo redirige a `/registro-taller`.
+
+## Backend asociado
+
+- `PUT /api/users/{id}/role`
+
+## Observaciones
+
+- Es la puerta de entrada al flujo de alta de talleres.
+- No crea el taller directamente; solo cambia el rol y prepara el registro.

--- a/documentacion/componentes/contacto.md
+++ b/documentacion/componentes/contacto.md
@@ -1,0 +1,34 @@
+# Contacto
+
+Esta pantalla permite contactar con un taller o enviar una solicitud general desde el frontend.
+
+## Componente principal
+
+- `ContactoComponent` en `frontend/src/app/components/contacto/`
+
+## Qué integra
+
+- listado de talleres
+- filtro por ubicación
+- mapa interactivo
+- formulario de contacto
+
+## Flujo de uso
+
+1. El componente carga los talleres disponibles.
+2. El usuario puede buscar por dirección o seleccionar uno en el mapa.
+3. Si quiere escribir un mensaje, abre el formulario de contacto.
+4. El formulario envía el mensaje al backend.
+5. En administración, el mensaje puede responderse desde el buzón.
+
+## Backend asociado
+
+- `GET /api/workshops`
+- `POST /api/contact`
+- `GET /api/admin/contact`
+- `POST /api/admin/contact/{id}/reply`
+
+## Observaciones
+
+- Reutiliza la lógica de geolocalización y el mapa para ordenar talleres por cercanía.
+- Es una puerta de entrada al contacto con la red de talleres.

--- a/documentacion/componentes/diagnostico.md
+++ b/documentacion/componentes/diagnostico.md
@@ -1,0 +1,44 @@
+# Diagnóstico
+
+Esta pantalla ejecuta el autodiagnóstico con IA y, si el usuario lo confirma, crea el issue de seguimiento.
+
+## Componente principal
+
+- `DiagnosticoComponent` en `frontend/src/app/components/diagnostico/`
+
+## Entrada de datos
+
+Recibe el estado de navegación desde `HomeComponent`:
+
+- vehículo técnico
+- síntomas seleccionados
+- descripción libre
+- `clientId`
+- `personalVehicleId`
+
+## Flujo de uso
+
+1. El componente valida que el contexto de navegación exista.
+2. Construye un `AutodiagnosisRequest`.
+3. Llama a `POST /api/autodiagnosis/diagnose`.
+4. Muestra diagnóstico, confianza, explicación y piezas sugeridas.
+5. Si el usuario acepta, llama a `POST /api/issues`.
+6. Después redirige a `/taller` para elegir taller.
+
+## Backend asociado
+
+- `POST /api/autodiagnosis/diagnose`
+- `POST /api/issues`
+
+## Respuesta que maneja
+
+- `diagnosis`
+- `confidence`
+- `explanation`
+- `suggestedParts`
+- `unresolvedPartNames`
+
+## Observaciones
+
+- La pantalla no solo muestra el resultado: también puede persistir el issue.
+- `sessionUuid` nace en este flujo y después conecta seguimiento y chat.

--- a/documentacion/componentes/home.md
+++ b/documentacion/componentes/home.md
@@ -1,0 +1,42 @@
+# Inicio
+
+Esta pantalla es el punto de entrada del usuario normal para el flujo de diagnóstico y alta de vehículos.
+
+## Componente principal
+
+- `HomeComponent` en `frontend/src/app/components/home/`
+
+## Qué integra
+
+- `IntroducirVehiculo`
+- `SeleccionaProblema`
+- `SelectorMisVehiculos`
+
+## Qué hace
+
+- Permite seleccionar un vehículo técnico o uno guardado en el garaje.
+- Recoge síntomas y descripción libre del problema.
+- Prepara el estado de navegación que después consume la pantalla de diagnóstico.
+- Permite guardar un coche nuevo en el garaje desde el mismo flujo.
+
+## Flujo de uso
+
+1. El componente comprueba el rol del usuario.
+2. Si es `TALLER` redirige a `/mecanico`.
+3. Si es `ADMIN` redirige a `/admin`.
+4. Si es usuario normal, carga sus vehículos personales.
+5. El usuario puede seleccionar un coche guardado o construir el contexto técnico manualmente.
+6. Al pulsar enviar, se navega a `/diagnostico` con el estado del vehículo y los síntomas.
+
+## Backend asociado
+
+- `GET /api/personal-vehicles?ownerId={ownerId}`
+- `POST /api/personal-vehicles`
+- `GET /api/vehicles/brands`
+- `GET /api/vehicles/brands/{brand}/models`
+- `GET /api/vehicles/{vehicleId}/variants`
+
+## Observaciones
+
+- Es la pantalla que conecta el catálogo técnico con el autodiagnóstico.
+- También funciona como punto de selección del vehículo personal activo.

--- a/documentacion/componentes/index.md
+++ b/documentacion/componentes/index.md
@@ -1,0 +1,18 @@
+# Índice de Componentes
+
+Este índice recoge la documentación de los componentes más importantes del frontend.
+
+- **Home**: Página principal — [documentacion/componentes/home.md](documentacion/componentes/home.md)
+- **Login**: Autenticación de usuarios — [documentacion/componentes/login.md](documentacion/componentes/login.md)
+- **Diagnóstico**: Flujo de autodiagnóstico y resultados — [documentacion/componentes/diagnostico.md](documentacion/componentes/diagnostico.md)
+- **Introducir vehículo**: Selección y alta de vehículo — [documentacion/componentes/introducir-vehiculo.md](documentacion/componentes/introducir-vehiculo.md)
+- **Selecciona problema**: Interfaz para elegir fallos — [documentacion/componentes/selecciona-problema.md](documentacion/componentes/selecciona-problema.md)
+- **Seguimiento**: Lista y detalle de seguimientos (`sessionUuid`) — [documentacion/componentes/seguimiento.md](documentacion/componentes/seguimiento.md)
+- **Taller**: Listado y selección de talleres — [documentacion/componentes/taller.md](documentacion/componentes/taller.md)
+- **Registro taller**: Formulario de solicitud de taller — [documentacion/componentes/registro-taller.md](documentacion/componentes/registro-taller.md)
+- **Mis vehículos**: Gestión de vehículos del usuario — [documentacion/componentes/mis-vehiculos.md](documentacion/componentes/mis-vehiculos.md)
+- **Perfil**: Página de perfil y ajustes — [documentacion/componentes/perfil.md](documentacion/componentes/perfil.md)
+- **Contacto**: Formulario de contacto y administración — [documentacion/componentes/contacto.md](documentacion/componentes/contacto.md)
+- **Mapa**: Integración de mapas para talleres/ubicación — [documentacion/componentes/map.md](documentacion/componentes/map.md)
+- **Cambiar rol**: Flujo de cambio de rol (admin) — [documentacion/componentes/cambiar-rol.md](documentacion/componentes/cambiar-rol.md)
+- **Sobre nosotros**: Información pública — [documentacion/componentes/sobre-nosotros.md](documentacion/componentes/sobre-nosotros.md)

--- a/documentacion/componentes/introducir-vehiculo.md
+++ b/documentacion/componentes/introducir-vehiculo.md
@@ -1,30 +1,68 @@
 # Introducción de Vehículo
 
-Este componente es el núcleo de la identificación técnica del vehículo en el proceso de diagnóstico.
+Este componente centraliza la selección de marca, modelo y detalle técnico del vehículo en los flujos de diagnóstico y alta de vehículos.
 
-## Estructura de Componentes
+## Componente principal
 
-`IntroducirVehiculo` actúa como un orquestador de tres sub-componentes especializados:
+- `IntroducirVehiculo` en `frontend/src/app/components/introducir-vehiculo/`
 
-1.  **SelectorMarcaModelo**: Gestiona la carga y selección de la marca y el modelo.
-2.  **PrecisionBusqueda**: Un indicador visual que muestra qué tan completa es la información proporcionada (Marca -> Modelo -> Detalle).
-3.  **DetalleVehiculo**: Permite especificar la variante exacta, motorización, transmisión y año.
+## Subcomponentes usados
 
-## Relación con la Capa MCP (LLM)
+1. `SelectorMarcaModelo`: carga y selección de marca y modelo.
+2. `PrecisionBusqueda`: muestra el nivel de completitud de la información.
+3. `DetalleVehiculo`: permite elegir variante, motor, transmisión y año.
 
-La información recopilada por este componente es crucial para el diagnóstico inteligente mediante IA:
+## Modos de uso
 
-*   **Contexto en el Prompt**: Toda la información del vehículo (`brand`, `model`, `engineType`, `transmission`, etc.) se envía al LLM como parte del contexto del diagnóstico.
-*   **Capa MCP**: El LLM utiliza herramientas de la capa MCP para consultar catálogos técnicos precisos.
-*   **Motorización y Piezas**: Basándose en la **motorización** exacta identificada por este componente, el LLM puede invocar herramientas MCP para filtrar y sugerir las piezas de repuesto específicas que son compatibles con ese vehículo exacto, evitando errores de compatibilidad.
+### `diagnostico`
 
-## Reutilización y Flujos
+- Se usa en el flujo de autodiagnóstico.
+- El usuario debe completar al menos marca y modelo.
+- El botón principal emite `enviar` para continuar.
 
-*   **Diagnóstico Anónimo/Usuario**: Se utiliza en el flujo principal para iniciar un diagnóstico.
-*   **Mis Vehículos**: Este componente se reutiliza en el apartado "Mis Vehículos" para permitir al usuario registrado añadir un nuevo vehículo a su garaje virtual con la misma precisión técnica.
+### `alta`
 
-## Comunicación con otros componentes
+- Se usa en `Mis Vehículos` para registrar un coche en el garaje.
+- Incluye matrícula, VIN y fecha de matriculación opcionales.
+- El botón principal emite `guardarCoche`.
 
-Emite eventos (`Output`) hacia el componente padre:
-*   `vehicleContextChange`: Notifica cada cambio en la selección del vehículo.
-*   `enviar`: Se dispara cuando el usuario confirma la información para proceder al diagnóstico.
+## Datos que recoge
+
+- `brand`
+- `modelId`
+- `modelName`
+- `variantId`
+- `variantName`
+- `engineType`
+- `transmission`
+- `year`
+
+En modo alta también recoge:
+
+- `plate`
+- `vin`
+- `buildDate`
+
+## Backend asociado
+
+- `GET /api/vehicles/brands`
+- `GET /api/vehicles/brands/{brand}/models`
+- `GET /api/vehicles/{vehicleId}/variants`
+- `POST /api/personal-vehicles`
+
+## Flujo funcional
+
+1. El componente carga marcas al iniciarse.
+2. Al elegir marca, carga modelos.
+3. Al elegir modelo, carga variantes técnicas.
+4. El padre recibe el contexto técnico con `vehicleContextChange`.
+5. En diagnóstico, el contexto se envía al motor IA.
+6. En alta, el contexto se usa para guardar el vehículo del usuario.
+
+## Integración con diagnóstico
+
+La información técnica se transforma en el `AutodiagnosisRequest` que después consume el backend.
+
+## Integración con `Mis Vehículos`
+
+En modo alta, el componente se reutiliza dentro de `MisVehiculosComponent` para crear un vehículo personal con la misma base técnica.

--- a/documentacion/componentes/login.md
+++ b/documentacion/componentes/login.md
@@ -1,0 +1,50 @@
+# Login y registro
+
+Este componente unifica inicio de sesión y registro de cuenta en una sola pantalla.
+
+## Componente principal
+
+- `LoginComponent` en `frontend/src/app/components/login/`
+
+## Modos
+
+### `login`
+
+- Pide correo y contraseña.
+- Llama a `POST /api/auth/login`.
+- Guarda la sesión en `AuthStateService`.
+
+### `register`
+
+- Pide nombre completo, correo, contraseña y rol.
+- Llama a `POST /api/auth/register`.
+- El rol inicial puede ser `USER`, `TALLER` o `ADMIN`.
+
+## Comportamiento del frontend
+
+- El componente cambia de modo entre `/login` y `/registro`.
+- Valida formato de email y contraseña antes de enviar.
+- Maneja errores de conflicto cuando el correo ya existe.
+- Redirige según el rol recibido del backend.
+
+## Redirecciones
+
+- `USER` → `/home` o `/usuario/seguimiento` si se registró.
+- `TALLER` → `/mecanico`.
+- `ADMIN` → `/admin`.
+
+## Backend asociado
+
+- `POST /api/auth/login`
+- `POST /api/auth/register`
+
+## Datos relevantes
+
+- `AuthUserResponseDTO`
+- `AuthUserRole`
+- `AuthStateService`
+
+## Observaciones
+
+- Es la puerta de entrada de toda la aplicación.
+- De aquí depende el estado de sesión que consumen el header, los guards y el resto de pantallas.

--- a/documentacion/componentes/mis-vehiculos.md
+++ b/documentacion/componentes/mis-vehiculos.md
@@ -1,0 +1,34 @@
+# Mis vehículos
+
+Esta pantalla permite ver, añadir y eliminar vehículos personales del usuario.
+
+## Componente principal
+
+- `MisVehiculosComponent` en `frontend/src/app/components/mis-vehiculos/`
+
+## Qué hace
+
+- Lista los vehículos del usuario autenticado.
+- Permite abrir el formulario de alta.
+- Reutiliza `IntroducirVehiculo` en modo `alta`.
+- Guarda el coche en el garaje del usuario.
+- Permite eliminar vehículos del listado.
+- Usa un vehículo guardado como contexto para el diagnóstico.
+
+## Flujo de uso
+
+1. El componente carga los vehículos del usuario con `listByOwner()`.
+2. Si el usuario añade uno nuevo, el subcomponente emite `guardarCoche`.
+3. El backend persiste el vehículo y la vista se actualiza.
+4. Al diagnosticar un vehículo, el componente navega a `/home` con `personalVehicleId`.
+
+## Backend asociado
+
+- `GET /api/personal-vehicles?ownerId={ownerId}`
+- `POST /api/personal-vehicles`
+- `DELETE /api/personal-vehicles/{id}?ownerId={ownerId}`
+
+## Observaciones
+
+- Es la base del garaje personal del usuario.
+- El vehículo seleccionado aquí puede reutilizarse en diagnóstico y seguimiento.

--- a/documentacion/componentes/perfil.md
+++ b/documentacion/componentes/perfil.md
@@ -1,0 +1,34 @@
+# Perfil
+
+Esta pantalla agrupa la gestión de datos personales, seguridad y preferencias del usuario.
+
+## Componente principal
+
+- `PerfilComponent` en `frontend/src/app/components/perfil/`
+
+## Qué integra
+
+- subrutas internas con `RouterOutlet`
+- navegación a información, seguridad, vehículo y preferencias
+- footer compartido
+- modal de borrado de cuenta
+
+## Flujo de uso
+
+1. El usuario entra en `/perfil`.
+2. El componente muestra un menú lateral o superior con las subsecciones.
+3. Cada subvista se carga de forma lazy dentro del `RouterOutlet`.
+4. El usuario puede cerrar sesión o borrar su cuenta.
+
+## Backend asociado
+
+- `GET /api/users/{id}`
+- `PUT /api/users/{id}`
+- `PUT /api/users/{id}/password`
+- `POST /api/users/{id}/avatar`
+- `DELETE /api/users/{id}`
+
+## Observaciones
+
+- La pantalla reutiliza el mismo estado de sesión que el resto de la aplicación.
+- La eliminación de cuenta usa un modal de confirmación antes de llamar al backend.

--- a/documentacion/componentes/registro-taller.md
+++ b/documentacion/componentes/registro-taller.md
@@ -1,36 +1,56 @@
 # Registro de Taller
 
-Este componente permite a los nuevos talleres solicitar unirse a la plataforma de AutoDiagnóstico.
+Este componente permite a un mecánico solicitar el alta de su taller desde el frontend.
 
-## Componentes y Estructura
+## Componente principal
 
-El componente principal es `RegistroTallerComponent`, ubicado en `frontend/src/app/components/registro-taller/`.
+- `RegistroTallerComponent` en `frontend/src/app/components/registro-taller/`
 
-### Campos del Formulario
+## Qué hace
 
-El formulario recopila información esencial para dar de alta tanto al taller como al usuario administrador del mismo.
+El formulario recoge los datos de la cuenta del mecánico y del taller:
 
-| Campo | Entidad Relacionada | Descripción |
+| Campo | Entidad | Uso |
 | :--- | :--- | :--- |
-| **Nombre del taller** | `Workshop.name` | Nombre comercial del establecimiento. |
-| **Dirección** | `Workshop.address` | Ubicación física completa. |
-| **Teléfono** | `Workshop.phone` | Contacto telefónico del taller. |
-| **Correo electrónico** | `Workshop.email` / `AppUser.email` | Email de contacto y login. |
-| **Horario** | `Workshop.schedule` | Horas de apertura y cierre. |
-| **Límite de vehículos** | `Workshop.vehicleLimit` | Capacidad máxima de vehículos simultáneos. |
-| **URL Foto/Logo** | `Workshop.photoUrl` | Enlace a una imagen del taller o logo. |
-| **Nombre completo** | `AppUser.fullName` | Nombre del responsable del taller. |
-| **Contraseña** | `AppUser.passwordHash` | Credenciales de acceso. |
+| Nombre del taller | `Workshop.name` | Nombre público del taller |
+| Dirección | `Workshop.address` | Ubicación física |
+| Teléfono | `Workshop.phone` | Contacto |
+| Correo electrónico | `Workshop.email` / `AppUser.email` | Login y contacto |
+| Horario | `Workshop.schedule` | Horario comercial |
+| Límite de vehículos | `Workshop.vehicleLimit` | Capacidad máxima |
+| URL foto / logo | `Workshop.photoUrl` | Imagen del taller |
+| Nombre completo | `AppUser.fullName` | Responsable de la cuenta |
+| Contraseña | `AppUser.passwordHash` | Credencial de acceso |
 
-## Lógica de Funcionamiento
+## Flujo real
 
-1.  **Validación en tiempo real**: Se validan los campos obligatorios y la coincidencia de contraseñas mediante Angular Signals y Computed properties.
-2.  **Simulación de envío**: Actualmente, el componente realiza una simulación de envío (frontend-only) mostrando un spinner de carga y una pantalla de éxito tras 1.2 segundos.
-3.  **Integración**: El enlace para acceder a este registro se encuentra en el `Footer` de la aplicación, bajo la sección de "Información".
+1. El componente comprueba que el usuario está autenticado.
+2. Llama a `WorkshopService.existsForMechanic(userId)` como failsafe.
+3. Si ya existe un taller o una solicitud asociada, redirige a `/home`.
+4. Si no existe, pre-rellena `fullName` y `email` desde la sesión.
+5. El usuario completa el formulario y selecciona la ubicación en el mapa.
+6. El componente envía la solicitud a `WorkshopApplicationApiService.submit()`.
+7. El backend guarda una `WorkshopApplication` en estado `PENDING`.
 
-## Diseño y Estilos
+## Backend asociado
 
-El componente utiliza el sistema de diseño global del proyecto (`styles.css`):
-*   **Clases globales**: Reutiliza `.card` para los contenedores y `.btn .btn-primary` para las acciones.
-*   **Variables CSS**: Utiliza tokens globales como `--color-primary`, `--spacing-md`, etc.
-*   **Responsividad**: Adaptado para dispositivos móviles mediante Media Queries que reorganizan el grid de campos.
+- `POST /api/workshop-applications`
+- `GET /api/workshops/exists-for-mechanic/{mechanicId}`
+
+## Validaciones visibles en el frontend
+
+- Campos obligatorios completos.
+- Coordenadas seleccionadas en el mapa.
+- Términos aceptados.
+- Límite mínimo de vehículos.
+
+## Diseño
+
+- Usa tarjetas y formularios del sistema global de estilos.
+- Incluye un mapa selector de ubicación.
+- Muestra un estado de comprobación mientras valida el usuario.
+
+## Observaciones
+
+- Ya no es una simulación frontend-only.
+- El flujo real persiste la solicitud y luego depende de la aprobación administrativa.

--- a/documentacion/componentes/seguimiento.md
+++ b/documentacion/componentes/seguimiento.md
@@ -1,0 +1,39 @@
+# Seguimiento
+
+Esta pantalla muestra los seguimientos activos del cliente y abre el detalle y el chat asociados a cada `sessionUuid`.
+
+## Componente principal
+
+- `SeguimientoComponent` en `frontend/src/app/components/seguimiento/`
+
+## Qué hace
+
+- Carga la lista de seguimientos del usuario.
+- Mantiene selección por `issueId` o por `sessionUuid`.
+- Guarda la sesión activa en `localStorage`.
+- Hace refresco automático cada 5 segundos.
+- Navega al detalle del seguimiento cuando el usuario selecciona un caso.
+
+## Flujo de uso
+
+1. El guard de seguimiento permite entrar solo si existe un seguimiento válido.
+2. El componente llama a `MechanicService.getTrackingsForClient(userId)`.
+3. Si hay un seguimiento seleccionado, conserva ese contexto.
+4. Si el usuario hace click en un caso, navega al detalle/chat.
+5. El componente actualiza la lista periódicamente.
+
+## Backend asociado
+
+- `GET /api/mechanic/client/{clientId}/trackings`
+- `GET /api/mechanic/tracking/{sessionUuid}`
+
+## Relación con chat
+
+- El `sessionUuid` se reutiliza para cargar mensajes.
+- El chat y el detalle leen la misma sesión.
+- El cliente y el mecánico ven el mismo hilo persistente.
+
+## Observaciones
+
+- Esta pantalla es el centro del seguimiento del caso.
+- No usa `clientId` como identificador de escritura, solo como filtro de listado.

--- a/documentacion/componentes/taller.md
+++ b/documentacion/componentes/taller.md
@@ -1,94 +1,50 @@
-# feat: implementar flujo de talleres y asignación mecánico-cliente
+# Talleres
 
-## Resumen
+Este componente muestra los talleres disponibles y permite al cliente seleccionar uno para iniciar o continuar su seguimiento.
 
-Este PR implementa el nuevo sistema de talleres, permitiendo a los clientes visualizar talleres disponibles, consultar ocupación, seleccionar un taller y crear automáticamente una sesión de seguimiento con el mecánico asignado.
+## Componente principal
 
----
+- `TallerComponent` en `frontend/src/app/components/taller/`
 
-## Funcionalidades implementadas
+## Qué muestra
 
-### Sistema de talleres
+- listado dinámico de talleres desde backend
+- dirección
+- horario
+- ocupación actual
+- mecánico asignado
+- vehículos en reparación
+- filtros por disponibilidad, horario y distancia
 
-* Listado dinámico de talleres desde backend
-* Vista detallada de:
-  * dirección
-  * contacto
-  * horario
-  * ocupación
-  * mecánico asignado
-  * vehículos en reparación
-* Integración completa frontend ↔ backend
+## Flujo de uso
 
----
+1. El componente carga talleres con `WorkshopService.listWorkshops(userId)`.
+2. Si el usuario tiene geolocalización disponible, ordena la lista por cercanía.
+3. El cliente puede filtrar por ocupación y por talleres abiertos.
+4. Al seleccionar un taller, el frontend comprueba que tenga un vehículo personal activo seleccionado.
+5. El componente llama a `WorkshopService.selectWorkshop()`.
+6. El backend crea o reutiliza la sesión de seguimiento con `sessionUuid`.
+7. El usuario navega a `/usuario/seguimiento/detalle`.
 
-## Selección de taller
+## Backend asociado
 
-### Flujo implementado
+- `GET /api/workshops`
+- `GET /api/workshops/{workshopId}`
+- `POST /api/workshops/{workshopId}/select`
+- `GET /api/workshops/exists-for-mechanic/{mechanicId}`
 
-1. El cliente visualiza talleres disponibles
-2. Selecciona un taller
-3. Backend crea automáticamente:
-   * `TallerAssignment`
-   * `sessionUuid`
-   * relación mecánico-cliente
-4. El usuario es redirigido automáticamente al seguimiento/chat
+## Reglas visuales y de negocio
 
----
+- Un taller lleno se marca como completo.
+- Si ya existe una sesión previa, el usuario puede volver a ella.
+- La lista se reordena con la posición del usuario cuando hay geolocalización.
+- La selección depende de un vehículo personal guardado previamente.
 
-## Persistencia
+## Relación con seguimiento
 
-Cada taller mantiene:
+La selección del taller no termina en el listado: genera la sesión de trabajo que después se usa en seguimiento y chat.
 
-* límite de vehículos
-* vehículos activos
-* mecánico responsable
-* sesiones persistentes de seguimiento
+## Observaciones
 
----
-
-## Frontend Angular
-
-### Añadido
-
-* nuevo `TallerComponent`
-* render dinámico de talleres
-* cálculo de ocupación
-* estado visual de talleres completos
-* integración de navegación hacia seguimiento
-
-### Mejoras UX
-
-* botón de actualización
-* bloqueo de selección en talleres llenos
-* recuperación automática de sesiones existentes
-* mensajes de error controlados
-
----
-
-## Backend Spring Boot
-
-### Añadido
-
-* DTOs de talleres
-* endpoints de listado y selección
-* lógica de asignación mecánico-cliente
-* persistencia de `sessionUuid`
-* control de capacidad de talleres
-
----
-
-## Manejo de errores
-
-Soporte para:
-
-* talleres completos
-* clientes sin sesión
-* errores de asignación
-* talleres inexistentes
-
----
-
-## Resultado
-
-El sistema ahora permite crear flujos completos de asignación entre cliente y mecánico mediante selección de talleres, dejando preparada la integración directa con seguimiento y chat persistente.
+- El componente usa `signals` y `computed` para filtros y ordenación.
+- La distancia se calcula con la fórmula de Haversine.

--- a/documentacion/data/scraping-coches.md
+++ b/documentacion/data/scraping-coches.md
@@ -1,0 +1,118 @@
+# Datos y Scraping de Coches
+
+Esta guía explica los recursos y scripts de scraping incluidos en el proyecto, la estructura de los JSON de salida y cómo importarlos al backend para poblar `Vehicle`, `VehicleModel`, `Engine` y `Product`.
+
+## Contenido relevante
+
+- `data/Scripts/RockAutoScrapping` — scraper Puppeteer que extrae catálogo de RockAuto y genera `vehicles_rockauto.json` en `frontend/src/assets/mocks/`.
+- `data/ultimatespecs-first-elements-v1-onlyFirstColumn.json` — ejemplo de fichero con especificaciones extraídas de UltimateSpecs; formato usado por `CarDataPopulationService`.
+- `data/PlanAccion.md` — mapeos de marcas y grupos automotrices para normalización.
+
+## RockAuto Scraper (qué hace y cómo usarlo)
+
+Ubicación: `data/Scripts/RockAutoScrapping`.
+
+Dependencias:
+
+```bash
+cd data/Scripts/RockAutoScrapping
+npm install
+```
+
+Ejecutar (ejemplo):
+
+```bash
+node index.js "https://www.rockauto.com/es/catalog/audi,2026,a3,2.0l+l4+turbocharged,3458296"
+```
+
+Comportamiento notable:
+
+- Usa `puppeteer` para abrir la página y expandir los nodos de catálogo.
+- Extrae nodos JSON embebidos (`input[id^="jsn"]`) y tablas de piezas (`listing_data_supplemental`).
+- Normaliza marca/modelo/año/motorización y agrupa "Recambios" por `groupname`/`parttype`.
+- Escribe el resultado en `frontend/src/assets/mocks/vehicles_rockauto.json`.
+
+Salida: objeto con keys `Marca`, `Modelo`, `Motorización`, `FechaFabricacion`, `Recambios` (cada recambio incluye `Nombre`, `Url`, `Piezas` con `Fabricante`, `NumeroPieza`, `Descripcion`, `Precio`, `Imagen`).
+
+Notas:
+
+- El script corre en modo `headful` por defecto (`headless: false`) para facilitar debugging; se puede ajustar.
+- A veces RockAuto cambia su DOM; las reglas de selección y parseo pueden requerir ajustes.
+
+## UltimateSpecs JSON (estructura y uso)
+
+El archivo `data/ultimatespecs-first-elements-v1-onlyFirstColumn.json` es un ejemplo del formato esperado por el pipeline de importación del backend.
+
+Estructura clave (resumida):
+
+- Array raíz. Cada elemento representa una "marca" o conjunto de modelos.
+- `models`: array de modelos, cada `model` contiene:
+  - `modelName` — nombre base del modelo.
+  - `imageUrl` — URL de imagen (opcional).
+  - `url` — URL de la ficha en UltimateSpecs.
+  - `versions`: array con variantes (cada variante puede representar motorizaciones o años). Cada `version` contiene:
+    - `table_versions`: array donde cada objeto representa una ficha técnica (clave→valor). Las claves contienen categorías como `Motores de Gasolina`, `Eléctrico`, `Año`, `Potencia`, etc. El código del backend busca la clave que contiene la categoría de motor para extraer el `modelName` y el `Año`.
+    - `specifications`: map con propiedades técnicas (`Batalla:`, `Alto:`, `Largo:`, `Ancho:`, `Peso:`, `Período de producción:`...).
+    - `url`: la URL concreta de la ficha.
+
+Cómo lo consume el backend (`CarDataPopulationService`):
+
+- `scanAndPopulate(rootPath)` recorre recursivamente `rootPath` buscando archivos `ultimatespecs-*.json`.
+- Para cada archivo detecta la "brand" por el nombre del fichero y asume que el fichero está dentro de una carpeta `Groups/<group>/<files>` — la carpeta padre se usa como `group`.
+- Para cada `version.table_versions`:
+  - `extractModelName` busca la clave que indica la categoría de motor y toma su valor como nombre del motor/variante.
+  - `detectEngineType` busca palabras en las claves (`Gasolina`, `Diesel`, `Eléctrico`, `HEV`, `PHEV`, `REEV`) para asignar `EngineType`.
+  - Se crean/actualizan `Engine`, `Vehicle`, `VehicleModel` y se infieren transmisiones con heurísticas.
+
+Campos mapeados (ejemplos):
+
+- `specifications` → `Vehicle`:
+
+  - `Batalla:` → `wheelbase`
+  - `Alto:` → `height`
+  - `Largo:` → `length`
+  - `Ancho:` → `width`
+  - `Peso:` → `weight`
+  - `Período de producción:` → `periodOfProduction`
+  - `Cilindrada:` → `engineDisplacement`
+- `table_versions` entry → `VehicleModel` `modelName`, `yearFirstProduction`, vinculado a `Engine` detectado.
+
+## Flujo de importación completo (pasos prácticos)
+
+1. Preparar los JSON de modelos (UltimateSpecs) y los JSON/carParts (RockAuto u otra fuente).
+   - Estructura recomendada en disco:
+     ```text
+     scraper-output/Groups/
+       |-- vag/
+       |     |-- ultimatespecs-volkswagen.json
+       |     |-- parts-volkswagen.json
+       |-- toyota/
+             |-- ultimatespecs-toyota.json
+             |-- parts-toyota.json
+     ```
+2. Si usas `RockAutoScrapping`, ejecuta `node index.js <rockauto-url>` para generar `vehicles_rockauto.json` y mueve/copia esos JSON a la carpeta del `group` correspondiente.
+3. Arrancar el `backend` (por ejemplo `./mvnw spring-boot:run`) sin datos previos (`vehicles/models/engines` vacíos) para que `CarDataPopulationRunner` ejecute `scanAndPopulate(rootPath)` automáticamente.
+   - Puedes pasar la opción `--rootPath=/ruta/a/scraper-output/Groups` si no usas la ruta por defecto.
+4. Verificar logs: `CarDataPopulationService` registra progreso al cargar modelos y plantillas de producto.
+5. Revisa la tabla `product` inicialización: `GeneralPartsInitializer` carga `static/general-car-parts.json` y `static/general-car-parts-*.json` para poblar productos generales.
+
+## Donde colocar los catálogos de piezas (MCP)
+
+- El `mcp-server` carga catálogos desde `classpath:parts-catalog/{ENGINE_TYPE}.json`. Para usar nuevas listas de piezas en el flujo LLM → tool_use, añade archivos `PETROL.json`, `DIESEL.json`, etc. en `mcp-server/src/main/resources/parts-catalog/`.
+
+## Consejos y advertencias
+
+- Normalización: usa `data/PlanAccion.md` para mapear marcas a grupos automotrices y evitar fragmentación de datos.
+- Anti-hallucination: el backend valida nombres de piezas contra `product` y registra `unresolved` cuando aparecen nombres no encontrados.
+- DOM frágil: scrapers basados en `puppeteer` pueden romperse con cambios en RockAuto o UltimateSpecs; mantén tests de extracción y ejemplos.
+- Respeta los términos de servicio y robots.txt de los sitios target. Para recolección masiva considera APIs oficiales o acuerdos.
+
+---
+
+Archivos referenciados:
+
+- `data/Scripts/RockAutoScrapping/index.js`
+- `data/ultimatespecs-first-elements-v1-onlyFirstColumn.json`
+- `backend/src/main/java/.../service/core/CarDataPopulationService.java`
+- `backend/src/main/java/.../service/core/CarDataPopulationRunner.java`
+- `backend/src/main/java/.../service/core/GeneralPartsInitializer.java`

--- a/documentacion/docker-compose.md
+++ b/documentacion/docker-compose.md
@@ -1,0 +1,97 @@
+# Docker Compose — cómo ejecutar los servicios
+
+Este documento explica el `docker-compose.yml` incluido en la raíz del proyecto y cómo usarlo para levantar los servicios necesarios (MySQL, MCP server, backend y frontend).
+
+## Servicios definidos
+
+- `mysql` (MySQL 8.0)
+
+  - Puerto: `3306:3306`
+  - Variables: `MYSQL_ROOT_PASSWORD=root`, `MYSQL_DATABASE=autodiagnostico`
+  - Volumen: `mysql_data:/var/lib/mysql`
+- `mcp-server`
+
+  - Construye a partir de `./mcp-server`
+  - Puerto expuesto: `5005:5005`
+  - Provee las tools (ej. `get_candidate_parts`) que consume el backend vía Spring AI MCP client.
+- `backend`
+
+  - Construye a partir de `./backend`
+  - Puerto host → contenedor: `7777:8081` (accesible en `http://localhost:7777`)
+  - Variables de entorno principales (también carga `env_file: .env`):
+    - `SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/autodiagnostico?createDatabaseIfNotExist=true`
+    - `SPRING_DATASOURCE_USERNAME=root`
+    - `SPRING_DATASOURCE_PASSWORD=root`
+    - `SPRING_JPA_HIBERNATE_DDL_AUTO=update`
+    - `GEMINI_API_KEY=${GEMINI_API_KEY}` (se debe proporcionar en `.env` o en el entorno)
+    - `SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_AUTODIAGNOSTICO_MCP_URL=http://mcp-server:5005`
+  - Volúmenes (para facilitar desarrollo/scraper output y assets):
+    - `./backend/src/main/resources/scraper-output:/app/scraper-output`
+    - `./backend/src/main/resources/logos:/app/logos`
+    - `./backend/src/main/resources/models:/app/models`
+  - Depende de `mysql` y `mcp-server`.
+- `frontend`
+
+  - Construye a partir de `./frontend`
+  - Puerto: `80:80` (la app estará disponible en `http://localhost`)
+  - Depende de `backend`.
+
+## Volúmenes
+
+- `mysql_data` — volumen Docker para persistencia de la base de datos MySQL.
+
+## Variables de entorno recomendadas
+
+Crea un archivo `.env` en la raíz con al menos las siguientes variables:
+
+```
+GEMINI_API_KEY=tu_api_key_de_gemini_o_modelo
+# Otras variables si las necesitas
+```
+
+Asegúrate de no incluir claves secretas en commits públicos.
+
+## Comandos básicos
+
+Levantar todos los servicios (en background):
+
+```bash
+docker compose up -d --build
+```
+
+Ver logs de un servicio (por ejemplo backend):
+
+```bash
+docker compose logs -f backend
+```
+
+Detener y eliminar contenedores (mantiene volúmenes):
+
+```bash
+docker compose down
+```
+
+Eliminar contenedores y volúmenes:
+
+```bash
+docker compose down -v
+```
+
+## Notas de desarrollo
+
+- El `backend` está configurado para conectarse al MCP server en `http://mcp-server:5005` dentro de la red Docker; no necesitas cambiar la URL para el entorno Docker Compose.
+- Si quieres depurar el backend localmente desde tu IDE (no en contenedor), ajusta `SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_AUTODIAGNOSTICO_MCP_URL` a `http://localhost:5005` y arranca `mcp-server` localmente.
+- Para probar la importación de datos con el runner (CarDataPopulationRunner), monta tu carpeta `scraper-output/Groups` dentro del contenedor `backend` o usa la opción `--rootPath` al iniciar el backend fuera del contenedor.
+
+## Consideraciones de seguridad
+
+- No metas claves en `.env` sin control de acceso.
+- En producción, protege el acceso a la base de datos y al MCP con redes privadas o mecanismos de autenticación.
+
+---
+
+Archivos referenciados:
+
+- `docker-compose.yml`
+- `mcp-server/src/main/resources/parts-catalog/`
+- `backend/src/main/resources/application.properties`

--- a/documentacion/flujo-frontend-backend.md
+++ b/documentacion/flujo-frontend-backend.md
@@ -1,0 +1,312 @@
+# Flujo frontend/backend
+
+Este documento explica cómo se conectan las pantallas de Angular con los endpoints REST del backend en los recorridos principales de la aplicación.
+
+Para ver el detalle de rutas, consulta [documentacion/api/api-tracking.md](api/api-tracking.md) y para ver las entidades, [documentacion/modelos-datos.md](modelos-datos.md).
+
+---
+
+## 1. Arranque de la aplicación
+
+### Frontend
+
+La aplicación Angular se configura desde `app.config.ts` y registra:
+
+- `provideRouter(routes)`
+- `provideHttpClient(withFetch())`
+- listeners globales de errores
+
+### Navegación inicial
+
+La ruta raíz redirige a `login`.
+
+```txt
+/ -> /login
+```
+
+### Guards principales
+
+- `authGuard`: protege las vistas que requieren sesión activa.
+- `seguimientoGuard`: protege el acceso a seguimientos y chat.
+- `adminGuard`: protege el panel de administración.
+
+---
+
+## 2. Autenticación y sesión
+
+### Pantalla
+
+- `/login`
+- `/registro`
+
+Ambas rutas usan el mismo componente y alternan entre inicio de sesión y alta.
+
+### Backend
+
+- `POST /api/auth/login`
+- `POST /api/auth/register`
+
+### Flujo
+
+1. El usuario envía email y contraseña, o los datos de registro.
+2. El backend valida la petición y devuelve `AuthUserResponseDTO`.
+3. El frontend guarda la sesión en `localStorage`.
+4. El header y los guards leen el estado compartido para decidir navegación y permisos.
+
+### Resultado
+
+- un `USER` accede a la zona cliente
+- un `TALLER` accede a mecánico y seguimiento
+- un `ADMIN` ve el panel y el menú de gestión
+
+---
+
+## 3. Flujo de cliente normal
+
+### Inicio y catálogo
+
+Pantallas principales:
+
+- `/home`
+- `/diagnostico`
+- `/taller`
+- `/mis-vehiculos`
+- `/perfil/*`
+
+### Backend más usado
+
+- `GET /api/vehicles/brands`
+- `GET /api/vehicles/brands/{brand}/models`
+- `GET /api/vehicles/{vehicleId}/variants`
+- `GET /api/personal-vehicles`
+- `POST /api/personal-vehicles`
+- `DELETE /api/personal-vehicles/{id}`
+- `GET /api/workshops`
+- `GET /api/workshops/{workshopId}`
+- `POST /api/workshops/{workshopId}/select`
+
+### Flujo resumido
+
+1. El usuario entra en `home` o `diagnostico`.
+2. Escoge vehículo o crea uno propio en `mis-vehiculos`.
+3. Consulta talleres disponibles.
+4. Selecciona un taller y genera seguimiento.
+5. El frontend navega a `usuario/seguimiento` para ver el caso y el chat.
+
+---
+
+## 4. Autodiagnóstico e issue
+
+### Pantalla
+
+- `/diagnostico`
+
+### Backend
+
+- `POST /api/autodiagnosis/diagnose`
+- `POST /api/issues`
+
+### Flujo
+
+1. El usuario rellena síntomas, texto libre y datos del vehículo.
+2. El frontend envía el payload a autodiagnóstico.
+3. El backend responde con diagnóstico, confianza, explicación y piezas sugeridas.
+4. Si el flujo debe persistirse, se crea un `Issue` con `sessionUuid`.
+5. Ese `sessionUuid` pasa a ser la clave del seguimiento y del chat.
+
+### Resultado funcional
+
+- el diagnóstico vive en backend
+- la conversación y el progreso del caso se conectan a través de `sessionUuid`
+
+---
+
+## 5. Seguimiento del cliente
+
+### Pantalla
+
+- `/usuario/seguimiento`
+- `/usuario/seguimiento/detalle`
+- `/usuario/seguimiento/chat`
+
+### Backend
+
+- `GET /api/mechanic/client/{clientId}/trackings`
+- `GET /api/mechanic/tracking/{sessionUuid}`
+- `GET /api/chat/mensajes`
+- `GET /api/chat/unread`
+- `POST /api/chat/mark-read`
+- `POST /api/chat/join`
+- `POST /api/chat/leave`
+
+### Flujo
+
+1. El cliente abre su lista de seguimientos.
+2. El frontend obtiene el `sessionUuid` del seguimiento activo.
+3. Entra en el detalle y en el chat usando ese UUID.
+4. El chat carga mensajes históricos y mensajes nuevos por polling.
+5. Cuando el usuario entra a la sala, el frontend hace `join` para registrar presencia.
+
+### Nota importante
+
+El cliente no trabaja con `clientId` para escribir cambios de seguimiento; el identificador funcional es `sessionUuid`.
+
+---
+
+## 6. Flujo del mecánico
+
+### Pantallas
+
+- `/mecanico`
+- `/mecanico/seguimiento`
+- `/mecanico/seguimiento/chat`
+- `/perfil/informacion`
+- `/perfil/seguridad`
+- `/perfil/vehiculo`
+- `/perfil/preferencias`
+
+### Backend
+
+- `GET /api/mechanic/{mechanicId}/clients`
+- `GET /api/mechanic/client/{clientId}/trackings`
+- `GET /api/mechanic/tracking/{sessionUuid}`
+- `POST /api/mechanic/{mechanicId}/tracking/{sessionUuid}/status`
+- `POST /api/mechanic/{mechanicId}/tracking/{sessionUuid}/tracking-update`
+- `POST /api/chat/join`
+- `POST /api/chat/mensajes`
+
+### Flujo
+
+1. El mecánico entra en su lista de clientes.
+2. Abre un caso concreto.
+3. El frontend resuelve el `sessionUuid` y entra al detalle/chat.
+4. Antes de enviar mensajes, el chat asegura la presencia en la sala.
+5. El mecánico actualiza estado o mensaje del seguimiento usando el UUID, no el cliente.
+
+### Resultado funcional
+
+- el mecánico ve varios seguimientos por cliente si existen
+- el estado del caso se actualiza sin depender del login
+- el chat sigue la misma sesión en todo momento
+
+---
+
+## 7. Alta de taller
+
+### Pantalla
+
+- `/cambiar-rol`
+- `/registro-taller`
+
+### Backend
+
+- `PUT /api/users/{id}/role`
+- `POST /api/workshop-applications`
+- `GET /api/workshop-applications/pending`
+- `POST /api/workshop-applications/{applicationId}/approve`
+- `POST /api/workshop-applications/{applicationId}/reject`
+- `DELETE /api/workshop-applications/workshops/{workshopId}`
+
+### Flujo
+
+1. El usuario normal puede convertirse a `TALLER` desde la pantalla de cambio de rol.
+2. Después rellena el formulario de solicitud de taller.
+3. El backend guarda la solicitud como `PENDING`.
+4. El administrador revisa las solicitudes desde el panel.
+5. Al aprobar, se crea el taller definitivo y se asocia al mecánico.
+
+### Resultado funcional
+
+- la solicitud es temporal
+- el taller real se crea solo cuando el admin aprueba
+- el frontend de admin refleja pendientes, talleres y acciones de borrado
+
+---
+
+## 8. Administración
+
+### Pantallas
+
+- `/admin`
+- `/admin/usuarios`
+- `/admin/gestiontaller`
+- `/admin/contacto`
+
+### Backend
+
+- `GET /api/users`
+- `GET /api/users/{id}`
+- `PUT /api/users/{id}`
+- `DELETE /api/users/{id}`
+- `PUT /api/users/{id}/role`
+- `GET /api/admin/contact`
+- `POST /api/admin/contact/{id}/reply`
+- `GET /api/workshop-applications/pending`
+- `POST /api/workshop-applications/{applicationId}/approve`
+- `POST /api/workshop-applications/{applicationId}/reject`
+- `DELETE /api/workshop-applications/workshops/{workshopId}`
+
+### Flujo
+
+1. El admin entra al dashboard.
+2. Gestiona usuarios, talleres y buzón desde pantallas separadas.
+3. El header global muestra accesos directos a las secciones admin.
+4. Cada acción se traduce en una llamada REST concreta y el frontend refresca su estado local.
+
+---
+
+## 9. Contacto y mensajes
+
+### Pantallas
+
+- `/contacto`
+- `/admin/contacto`
+
+### Backend
+
+- `POST /api/contact`
+- `GET /api/admin/contact`
+- `POST /api/admin/contact/{id}/reply`
+
+### Flujo
+
+1. El usuario envía un mensaje desde contacto.
+2. El backend lo almacena como `ContactMessage`.
+3. El admin lo revisa en el buzón.
+4. Si procede, responde desde la misma pantalla.
+
+---
+
+## 10. Relación entre frontend y backend
+
+```mermaid
+flowchart LR
+    A[Angular routes] --> B[Guards]
+    B --> C[Componentes]
+    C --> D[Servicios HTTP]
+    D --> E[REST API Spring Boot]
+    E --> F[Base de datos MySQL]
+
+    C --> G[Estado local / localStorage]
+    D --> H[sessionUuid]
+    H --> I[Issue / Chat / Tracking]
+```
+
+---
+
+## 11. Puntos críticos del diseño
+
+- `sessionUuid` conecta issue, tracking y chat.
+- El frontend no debe asumir que `clientId` sirve para escribir cambios de seguimiento.
+- Los guards son la primera barrera de navegación, pero la seguridad real debe seguir estando en backend.
+- El panel admin y el header comparten rutas y accesos, así que el estado de sesión debe mantenerse sincronizado.
+
+---
+
+## 12. Documentos relacionados
+
+- [API del backend](api/api-tracking.md)
+- [Modelo de datos](modelos-datos.md)
+- [Seguimientos: sessionUuid y cambios recientes](logica/seguimiento-sessionUuid.md)
+- [Sistema Mecánico ↔ Cliente](logica/mecanico-user-flow.md)
+- [Flujo de creación de taller](flujo-creacion-taller.md)

--- a/documentacion/indice-por-flujo.md
+++ b/documentacion/indice-por-flujo.md
@@ -1,0 +1,71 @@
+# Índice por flujo
+
+Este documento organiza la documentación por flujos funcionales para que encuentres rápidamente los componentes, endpoints y modelos relacionados.
+
+## 1. Autenticación y Onboarding
+- Componentes frontend:
+  - [Login](componentes/login.md) — formulario de acceso y registro.
+- Backend / modelos:
+  - [API de autenticación](api/api-tracking.md#auth)
+  - [Modelo de usuario](modelos-datos.md#appuser)
+
+## 2. Flujo de Autodiagnóstico
+- Componentes frontend:
+  - [Diagnóstico](componentes/diagnostico.md)
+  - [Selecciona problema](componentes/selecciona-problema.md)
+- Backend / modelos:
+  - [Endpoint de autodiagnóstico](api/api-tracking.md#autodiagnosis)
+  - [Modelo `Product` / resultados](modelos-datos.md#product)
+
+## 3. Gestión de Vehículos (cliente)
+- Componentes frontend:
+  - [Introducir vehículo](componentes/introducir-vehiculo.md)
+  - [Mis vehículos](componentes/mis-vehiculos.md)
+- Backend / modelos:
+  - [Vehículos y modelos](modelos-datos.md#vehicle)
+  - [PersonalVehicle](modelos-datos.md#personalvehicle)
+
+## 4. Búsqueda y Selección de Taller
+- Componentes frontend:
+  - [Taller](componentes/taller.md)
+  - [Mapa](componentes/map.md)
+- Backend / modelos:
+  - [Workshops / WorkshopApplication](modelos-datos.md#workshop)
+  - [Flujo de creación de taller](flujo-creacion-taller.md)
+  - [API de talleres](api/api-tracking.md#workshop)
+
+## 5. Registro y Aprobación de Talleres (admin)
+- Componentes frontend:
+  - [Registro taller](componentes/registro-taller.md)
+  - [Admin: Gestión taller](componentes/admin.md)
+- Backend / modelos:
+  - [WorkshopApplication endpoints](api/api-tracking.md#workshop-application)
+  - [Estados de `WorkshopApplication`](modelos-datos.md#workshopapplication)
+
+## 6. Seguimiento y Chat (sessionUuid)
+- Componentes frontend:
+  - [Seguimiento](componentes/seguimiento.md)
+  - Componentes de chat y detalle dentro del flujo de seguimiento.
+- Backend / modelos:
+  - [Issue, ChatMessage, ChatRoomPresence](modelos-datos.md#issue)
+  - [API de chat y seguimiento](api/api-tracking.md#chat)
+  - [Flujo frontend ↔ backend para seguimientos](flujo-frontend-backend.md)
+
+## 7. Contacto y Administración
+- Componentes frontend:
+  - [Contacto](componentes/contacto.md)
+  - [Admin: Gestión usuarios / contacto](componentes/admin.md)
+- Backend / modelos:
+  - [ContactMessage](modelos-datos.md#contactmessage)
+  - [API de contacto](api/api-tracking.md#contact)
+
+## 8. Perfil y Ajustes del Usuario
+- Componentes frontend:
+  - [Perfil](componentes/perfil.md)
+  - [Cambiar rol (admin)](componentes/cambiar-rol.md)
+- Backend / modelos:
+  - [Endpoints de usuario](api/api-tracking.md#user)
+
+---
+
+Si necesitas, puedo generar una versión imprimible (PDF) de este índice o añadir una tabla de dependencias entre flujos (por ejemplo: qué endpoints son críticos para cada flujo).

--- a/documentacion/mcp-flujo-ia-backend.md
+++ b/documentacion/mcp-flujo-ia-backend.md
@@ -1,0 +1,98 @@
+# MCP: Flujo de IA ↔ Backend
+
+Este documento describe cómo funciona el MCP (Model Callback Provider) en el proyecto, cómo se expone la herramienta de catálogo de piezas y cómo el backend orquesta el flujo de autodiagnóstico usando un LLM.
+
+## Componentes principales
+
+- `mcp-server` (Spring Boot)
+
+  - Expone herramientas (tools) a través del starter `spring-ai-starter-mcp-server-webmvc`.
+  - Herramienta principal: `CandidatePartsTool.get_candidate_parts(engineType)`.
+  - Carga catálogos de piezas desde `classpath:parts-catalog/{ENGINE_TYPE}.json`.
+  - Configuración en `mcp-server/src/main/resources/application.properties`:
+    - `spring.ai.mcp.server.enabled=true`
+    - `spring.ai.mcp.server.name=autodiagnostico-mcp`
+    - `spring.ai.mcp.server.type=async`
+- `backend` (Spring Boot)
+
+  - Usa `spring-ai-starter-model-google-genai` para el cliente LLM (Gemini) y
+    `spring-ai-starter-mcp-client-webflux` para consumir el MCP remoto.
+  - Construye un `ChatClient` con `defaultToolCallbacks(mcpToolCallbackProvider)`
+    en `AiConfig` para que el LLM pueda invocar las tools del `mcp-server`.
+  - Orquesta el flujo de autodiagnóstico en `AutodiagnosisService`.
+
+## Flujo (resumen)
+
+1. El backend recibe una petición de autodiagnóstico (`AutodiagnosisController`).
+2. Resuelve el `VehicleModel` (base de datos) para obtener `engineType` y contexto.
+3. Construye el `userPrompt` y llama al LLM mediante `diagnosisChatClient`.
+   - El `ChatClient` está configurado con las callbacks del MCP, por lo que
+     durante la generación el LLM puede invocar `get_candidate_parts("ENGINE")`.
+4. El LLM debe invocar la tool y luego devolver un JSON estricto con diagnóstico
+   y el array `selectedPartNames` (reglas definidas en `AutodiagnosisService.SYSTEM_PROMPT`).
+5. El backend valida `selectedPartNames` contra la tabla `product` (anti-hallucination).
+6. Se devuelve al cliente el `AutodiagnosisResponseDTO` con piezas resueltas y
+   una lista de nombres no resueltos (si existieran).
+
+## Reglas importantes (enforceadas)
+
+- El sistema requiere que el LLM invoque `get_candidate_parts(engineType)` ANTES de
+  seleccionar piezas. Esto se fuerza en el `SYSTEM_PROMPT` y se comprueba por diseño
+  (el backend ignora nombres fuera de la lista devuelta por la tool).
+- El JSON de salida del LLM debe tener la forma exacta solicitada por el prompt.
+- `selectedPartNames` solo puede contener nombres exactamente iguales a los
+  devueltos por la tool — el backend utiliza `productRepository.findByName(...)`
+  para validar y enriquecer los resultados.
+
+## Cómo añadir o actualizar catálogos de piezas
+
+1. Añadir un archivo JSON en `mcp-server/src/main/resources/parts-catalog/` llamado
+   `ENGINE_TYPE.json` (p. ej. `PETROL.json`, `DIESEL.json`, `BEV.json`).
+2. Cada archivo debe ser un array JSON plano con objetos:
+   ```json
+   [{"name":"Bomba de combustible","description":"...","priceRange":[10,50]}, ...]
+   ```
+3. Reiniciar `mcp-server` para que `PartsCatalogService` cargue los catálogos.
+
+## Configuración y despliegue
+
+- Docker Compose define la conexión MCP para el backend:
+  - Variable: `SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_AUTODIAGNOSTICO_MCP_URL`
+  - En `docker-compose.yml` apunta a `http://mcp-server:5005` cuando se ejecuta
+    en el mismo stack.
+- Para desarrollo local:
+  - Ejecuta el `mcp-server` en `autodiagnostico26/mcp-server`:
+    ```bash
+    cd autodiagnostico26/mcp-server
+    ./mvnw spring-boot:run
+    ```
+  - Ejecuta el `backend` con la propiedad `spring.ai.mcp.client.sse.connections.autodiagnostico-mcp.url`
+    apuntando a `http://localhost:5005` (ya configurado en `application-local.properties`).
+
+## Pruebas y verificación
+
+- Verificar que el MCP arranca y carga catálogos: revisa logs de `PartsCatalogService`.
+- Prueba de integración manual:
+  1. Enviar una petición de autodiagnóstico al backend (cURL o Postman).
+  2. Observar en logs del backend la invocación al LLM y las llamadas a la tool.
+  3. Confirmar que `selectedPartNames` son validadas contra la BD y que
+     los `unresolved` aparecen si hay nombres no encontrados.
+
+## Consideraciones de seguridad y costes
+
+- Las llamadas al LLM (Gemini/Claude) generan coste por token; controlar
+  `temperature`, `max-output-tokens` y batching en `application.properties`.
+- Validar entradas del usuario y evitar exponer datos sensibles en prompts.
+- El MCP expone una API interna para tools: restringir acceso en producción
+  (networking / autenticación) para que solo el backend autorizado lo consuma.
+
+---
+
+Archivos clave referenciados:
+
+- `mcp-server/src/main/java/.../CandidatePartsTool.java`
+- `mcp-server/src/main/java/.../PartsCatalogService.java`
+- `backend/src/main/java/.../config/AiConfig.java`
+- `backend/src/main/java/.../service/autodiagnosis/AutodiagnosisService.java`
+- `mcp-server/src/main/resources/parts-catalog/` (JSONs)
+- `docker-compose.yml` (variable `SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_AUTODIAGNOSTICO_MCP_URL`)

--- a/documentacion/modelos-datos.md
+++ b/documentacion/modelos-datos.md
@@ -1,0 +1,347 @@
+# Modelo de datos
+
+Este documento resume las entidades persistentes principales de AutoDiagnóstico 26 y cómo se relacionan entre sí.
+
+Para ver los endpoints concretos, consulta [documentacion/api/api-tracking.md](api/api-tracking.md).
+
+---
+
+## Visión general
+
+El dominio gira alrededor de estos ejes:
+
+- usuarios y roles
+- vehículos personales
+- talleres y solicitudes de alta
+- issues de autodiagnóstico
+- seguimiento mecánico
+- chat persistente
+- mensajes de contacto
+
+La clave transversal del flujo de seguimiento es `sessionUuid`.
+
+---
+
+## Entidades principales
+
+### `AppUser`
+
+Tabla: `app_users`
+
+Representa a cualquier usuario de la plataforma.
+
+Campos relevantes:
+
+- `id`
+- `fullName`
+- `email`
+- `passwordHash`
+- `role`
+- `avatarUrl`
+- `createdAt`
+- `city`
+- `postalCode`
+
+Uso:
+
+- autenticación y perfil
+- cliente final
+- mecánico / taller
+- administrador
+
+### `Workshop`
+
+Tabla: `workshop`
+
+Representa el taller aprobado de un mecánico.
+
+Campos relevantes:
+
+- `id`
+- `name`
+- `address`
+- `phone`
+- `email`
+- `schedule`
+- `photoUrl`
+- `vehicleLimit`
+- `mechanicId`
+- `latitude`
+- `longitude`
+
+Uso:
+
+- listado público de talleres
+- selección por parte del cliente
+- relación con el mecánico dueño del taller
+
+### `WorkshopApplication`
+
+Tabla: `workshop_application`
+
+Representa la solicitud de alta de un taller.
+
+Campos relevantes:
+
+- `id`
+- `applicantFullName`
+- `applicantEmail`
+- `passwordHash`
+- `workshopName`
+- `address`
+- `phone`
+- `email`
+- `schedule`
+- `photoUrl`
+- `vehicleLimit`
+- `latitude`
+- `longitude`
+- `status`
+- `approvedWorkshop`
+- `approvedMechanic`
+- `createdAt`
+- `reviewedAt`
+
+Estados:
+
+- `PENDING`
+- `APPROVED`
+- `REJECTED`
+
+### `PersonalVehicle`
+
+Tabla: `personal_vehicle`
+
+Representa un vehículo de propiedad de un usuario.
+
+Campos relevantes:
+
+- `id`
+- `vehicleModel`
+- `owner`
+- `buildDate`
+- `vin`
+- `plate`
+
+Uso:
+
+- catálogo privado del cliente
+- base para crear issues y seleccionar taller
+
+### `Vehicle`
+
+Tabla: `vehicle`
+
+Representa la marca y el modelo base extraídos del catálogo.
+
+Campos relevantes:
+
+- `idVehicle`
+- `brand`
+- `name`
+- atributos técnicos de scraping como `wheelbase`, `height`, `length`, `width`, `weight`, `periodOfProduction`, `engineDisplacement`
+
+Relación:
+
+- un `Vehicle` tiene muchos `VehicleModel`
+
+### `VehicleModel`
+
+Tabla: `vehicle_model`
+
+Representa una variante concreta de un vehículo.
+
+Campos relevantes:
+
+- `idVehicleModel`
+- `vehicle`
+- `modelName`
+- `yearFirstProduction`
+- `transmission`
+- `engine`
+
+Relación:
+
+- un `VehicleModel` pertenece a un `Vehicle`
+- un `VehicleModel` puede tener muchos `PersonalVehicle`
+
+### `Product`
+
+Tabla: `product`
+
+Representa una pieza o producto sugerido por el autodiagnóstico.
+
+Campos relevantes:
+
+- `idProduct`
+- `name`
+- `description`
+- `lowRangePrice`
+- `highRangePrice`
+- `image`
+
+Uso:
+
+- salida del motor de diagnóstico
+- sugerencias de reparación para el cliente o mecánico
+
+### `Issue`
+
+Tabla: `issue`
+
+Representa el seguimiento principal de un caso abierto por autodiagnóstico.
+
+Campos relevantes:
+
+- `id`
+- `personalVehicle`
+- `workshop`
+- `description`
+- `aiDiagnosis`
+- `recommendedParts`
+- `estimatedPrice`
+- `status`
+- `progressColor`
+- `latestUpdate`
+- `budgetAmount`
+- `acceptedAt`
+- `inProgressAt`
+- `fixedAt`
+- `active`
+- `sessionUuid`
+- `createdAt`
+- `updatedAt`
+
+Notas:
+
+- `sessionUuid` es la clave lógica del seguimiento.
+- el chat, el tracking y las actualizaciones del mecánico usan ese UUID.
+- el issue puede existir antes de asignar taller.
+
+Estados:
+
+- `DRAFT`
+- `WORKSHOP_ASSIGNED`
+- `BUDGET_ACCEPTED`
+- `IN_PROGRESS`
+- `RESOLVED`
+- `CANCELLED`
+- `FIXED`
+
+### `ChatMessage`
+
+Tabla: `chat_message`
+
+Representa cada mensaje persistente del chat de seguimiento.
+
+Campos relevantes:
+
+- `id`
+- `issue`
+- `sender`
+- `senderRole`
+- `sessionUuid`
+- `commentText`
+- `wordCount`
+- `readByUser`
+- `createdAt`
+
+Estados / roles:
+
+- `MECANICO`
+- `USUARIO`
+
+Notas:
+
+- los mensajes se agrupan por `sessionUuid`
+- el sender puede ser nulo en algunos flujos internos, pero el rol siempre identifica el origen funcional
+
+### `ChatRoomPresence`
+
+Tabla: `chat_room_presence`
+
+Representa la presencia de cada participante en una sala de seguimiento.
+
+Campos relevantes:
+
+- `id`
+- `issue`
+- `participant`
+- `active`
+- `joinedAt`
+- `updatedAt`
+
+Restricción importante:
+
+- un participante solo puede tener una fila activa por issue
+
+### `ContactMessage`
+
+Tabla: `contact_message`
+
+Representa un mensaje enviado desde el formulario de contacto.
+
+Campos relevantes:
+
+- `id`
+- `name`
+- `email`
+- `phone`
+- `message`
+- `workshopId`
+- `createdAt`
+- `repliedAt`
+- `replyMessage`
+
+Uso:
+
+- buzón de administración
+- respuesta manual desde el panel admin
+
+---
+
+## Flujo de datos más importante
+
+### 1. Autodiagnóstico
+
+1. El cliente lanza el diagnóstico sobre un vehículo personal.
+2. El backend devuelve una sugerencia con piezas, diagnóstico y explicación.
+3. Si el caso se materializa, se crea un `Issue` con `sessionUuid`.
+
+### 2. Seguimiento
+
+1. El mecánico abre el seguimiento por `sessionUuid`.
+2. Actualiza estado y mensaje usando ese mismo UUID.
+3. El cliente ve el progreso desde su lista de seguimientos.
+
+### 3. Chat
+
+1. Cliente y mecánico hacen `join` en la misma sala.
+2. Los mensajes se guardan en `chat_message`.
+3. La presencia activa se controla en `chat_room_presence`.
+
+### 4. Alta de taller
+
+1. El formulario crea una `WorkshopApplication`.
+2. El administrador aprueba o rechaza la solicitud.
+3. Si se aprueba, se crea el `Workshop` definitivo y se asocia al mecánico.
+
+---
+
+## Observaciones de diseño
+
+- `sessionUuid` es la llave funcional central del seguimiento.
+- `Issue` es el modelo que conecta vehículo, taller, diagnóstico y chat.
+- `WorkshopApplication` es temporal; `Workshop` es el resultado aprobado.
+- `ChatRoomPresence` existe para controlar la presencia antes de permitir mensajes.
+- `ContactMessage` es independiente del flujo de seguimiento.
+
+---
+
+## Documentos relacionados
+
+- [API del backend](api/api-tracking.md)
+- [Flujo de creación de taller](flujo-creacion-taller.md)
+- [Seguimientos: sessionUuid y cambios recientes](logica/seguimiento-sessionUuid.md)
+- [Sistema de Chat](logica/chat-system.md)
+- [Sistema Mecánico ↔ Cliente](logica/mecanico-user-flow.md)


### PR DESCRIPTION
# PR: Guía rápida — Dónde revisar la documentación del proyecto

## Resumen

Este PR añade una guía concisa para que los revisores sepan dónde encontrar y cómo validar la documentación técnica del proyecto. Incluye rutas, comandos rápidos para abrir los archivos y una propuesta de pasos de verificación.

## Archivos creados/actualizados (documentación relevante)

- `documentacion/README.md` — portada de la documentación (índices por flujo y por componentes).
- `documentacion/indice-por-flujo.md` — tabla de contenidos organizada por flujos funcionales.
- `documentacion/componentes/index.md` — índice de componentes UI.
- `documentacion/mcp-flujo-ia-backend.md` — descripción del MCP (tools), configuración y flujo LLM ↔ backend.
- `documentacion/data/scraping-coches.md` — guía de scrapers (RockAuto), formato UltimateSpecs y procedimiento de importación.
- `documentacion/componentes/*` — varios archivos de componentes (login, home, seguimiento, taller, etc.)
- `LICENSE` — actualizado a MIT con atribución al proyecto.

## Dónde mirar (rutas en el repo)

- Portada documentación: `documentacion/README.md`
- Índice por flujo: `documentacion/indice-por-flujo.md`
- MCP/IA: `documentacion/mcp-flujo-ia-backend.md`
- Datos / Scraping: `documentacion/data/scraping-coches.md`
- Modelos de datos: `documentacion/modelos-datos.md`
- API: `documentacion/api/api-tracking.md`
- Componentes UI: `documentacion/componentes/index.md` (y cada archivo en `documentacion/componentes/`)